### PR TITLE
Fix 2.7 compatibility issue in ThreadLocalState

### DIFF
--- a/beeline/state.py
+++ b/beeline/state.py
@@ -20,8 +20,8 @@ class ThreadLocalState(State):
         self._state = threading.local()
 
     def reset(self):
-        self._event_stack().clear()
-        self._trace_stack().clear()
+        self._state.trace_stack = []
+        self._state.event_stack = []
 
     def _trace_stack(self):
         if not hasattr(self._state, 'trace_stack'):

--- a/beeline/test_state.py
+++ b/beeline/test_state.py
@@ -85,3 +85,12 @@ class TestThreadLocalState(unittest.TestCase):
         self.assertEqual(e, e2)
         e = state.pop_event()
         self.assertEqual(e, e1)
+
+    def test_event_state_reset(self):
+        e1 = Mock()
+        state = ThreadLocalState()
+
+        state.add_event(e1)
+        self.assertEqual(state.get_current_event(), e1)
+        state.reset()
+        self.assertEqual(state.get_current_event(), None)


### PR DESCRIPTION
In 2.7, list does not have a clear() method. Reset state by creating a new list.