### PR TITLE
some django middleware improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ Note that Honeycomb API keys have the ability to create and delete data, and sho
 
 The beeline uses Django's request/response middleware (>1.10) and database query execution wrapper (>2.0) to automatically instrument your HTTP requests and database queries, and also supports tracing.
 
-To begin, add the middleware to your settings.py file. Choose `HoneyMiddlewareHttpOnly` if you do not want db instrumentation, or `HoneyMiddlewareHttpAndDb` if you do want db instrumentation.
+To begin, add the middleware to your settings.py file. Choose `HoneyMiddlewareHttp` if you do not want db instrumentation, or `HoneyMiddleware` if you do want db instrumentation.
 
 ```python
 MIDDLEWARE = [
-  'beeline.middleware.django.HoneyMiddlewareHttpAndDb',
+  'beeline.middleware.django.HoneyMiddleware',
 ]
 ```
 

--- a/beeline/middleware/django/__init__.py
+++ b/beeline/middleware/django/__init__.py
@@ -23,7 +23,8 @@ class HoneyDBWrapper(object):
                 beeline.add_field(
                     "db.duration", db_call_diff.total_seconds() * 1000)
             except Exception as e:
-                beeline.add_field("db.error", str(type(e)) + ': ' + str(e))
+                beeline.add_field("db.error", str(type(e)))
+                beeline.add_field("db.error_detail", str(e))
                 raise
             else:
                 return result
@@ -35,7 +36,7 @@ class HoneyDBWrapper(object):
                     })
 
 
-class HoneyMiddleware(object):
+class HoneyMiddlewareBase(object):
     def __init__(self, get_response):
         self.get_response = get_response
 
@@ -77,11 +78,11 @@ class HoneyMiddleware(object):
         beeline.add_field("request.error_detail", str(exception))
 
 
-class HoneyMiddlewareHttpOnly(HoneyMiddleware):
+class HoneyMiddlewareHttp(HoneyMiddlewareBase):
     pass
 
 
-class HoneyMiddlewareHttpAndDb(HoneyMiddleware):
+class HoneyMiddleware(HoneyMiddlewareBase):
     def __call__(self, request):
         try:
             db_wrapper = HoneyDBWrapper()


### PR DESCRIPTION
* allow users to choose http only middleware, or http **and** db middleware
* fix db.error, request.query, and request.post fields
* add request.error_detail field to http 500 events (It doesn't look like it's possible to pick out the error type. The exception is just a string saying what problem occurred.)