### PR TITLE
Add lambda wrapper

### DIFF
--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -128,7 +128,22 @@ def add(data):
 
 
 def tracer(name):
-    return g_tracer(name)
+    '''
+    When used in a context manager, creates a trace event for the contained
+    code. If existing trace context data is available, will mark the event as a
+    child of the most recent trace span.
+
+    Example use:
+
+    ```
+    with tracer(name="call to db"):
+        issue_db_query()
+    ```
+
+    Args:
+    - `name`: a descriptive name for the this trace span, i.e. "database query for user"
+    '''
+    return g_tracer(name=name)
 
 
 def _new_event(data=None, trace_name='', top_level=False):

--- a/beeline/middleware/awslambda/__init__.py
+++ b/beeline/middleware/awslambda/__init__.py
@@ -1,0 +1,46 @@
+import beeline
+
+def _get_trace_ids(event):
+    ''' Extract trace/parent ids that are threaded through in various ways '''
+    trace_id, parent_id = None, None
+
+    # If API gateway is triggering the Lambda, the event will have headers
+    # and we can look for our trace headers
+    if isinstance(event, dict):
+        if 'headers' in event:
+            if isinstance(event['headers'], dict):
+                # deal with possible case issues
+                keymap = {k.lower(): k  for k in event['headers'].keys()}
+                if 'x-honeycomb-trace-id' in keymap:
+                    trace_id = event['headers'][keymap['x-honeycomb-trace-id']]
+                if 'x-honeycomb-parent-id' in keymap:
+                    parent_id = event['headers'][keymap['x-honeycomb-parent-id']]
+
+    return trace_id, parent_id
+
+def wrap(handler, event, context):
+    # don't blow up the world if the beeline has not been initialized
+    if not beeline.g_client or not beeline.g_tracer:
+        return handler(event, context)
+
+    try:
+        # if we've passed a trace id from a previous lambda, it will
+        # be here
+        trace_id, parent_id = _get_trace_ids(event)
+        with beeline.g_tracer(name=handler.__name__,
+                trace_id=trace_id, parent_id=parent_id):
+            beeline.add({
+                "app.function_name": context.function_name,
+                "app.function_version": context.function_version,
+                "app.request_id": context.aws_request_id,
+                "app.event": event,
+            })
+            resp = handler(event, context)
+
+            if resp is not None:
+                beeline.add_field('app.response', resp)
+
+            return resp
+    finally:
+        # we have to flush events before the lambda returns
+        beeline.g_client.flush()

--- a/beeline/middleware/awslambda/test_awslambda.py
+++ b/beeline/middleware/awslambda/test_awslambda.py
@@ -1,0 +1,28 @@
+import unittest
+
+from beeline.middleware import awslambda
+
+class TestGetTraceIds(unittest.TestCase):
+    def test_get_trace_ids_from_header(self):
+        ''' test that trace_id and parent_id are extracted regardless of case '''
+        event = {
+            'headers': {
+                # case shouldn't matter
+                'X-HoNEyComb-TrACE-id': 'bloop',
+                'x-HoNEyComb-PARENT-ID': 'scoop',
+            },
+        }
+
+        trace_id, parent_id = awslambda._get_trace_ids(event)
+        self.assertEqual(trace_id, 'bloop')
+        self.assertEqual(parent_id, 'scoop')
+
+    def test_get_trace_ids_no_header(self):
+        ''' ensure that we handle events with no header key '''
+        event = {
+            'foo': 1,
+        }
+
+        trace_id, parent_id = awslambda._get_trace_ids(event)
+        self.assertIsNone(trace_id)
+        self.assertIsNone(parent_id)

--- a/beeline/state.py
+++ b/beeline/state.py
@@ -36,14 +36,17 @@ class ThreadLocalState(State):
 
     def _trace_id(self):
         if not hasattr(self._state, 'trace_id'):
-            self._state.trace_id = None
+            self._state.trace_id = ''
         return self._state.trace_id
 
-    def start_trace(self):
+    def start_trace(self, trace_id=None, parent_id=None):
+        if trace_id:
+            self._state.trace_id = trace_id
         if not self._trace_id():
             self._state.trace_id = str(uuid.uuid4())
         trace_stack = self._trace_stack()
-        parent_id = trace_stack[-1] if trace_stack else None
+        if not parent_id:
+            parent_id = trace_stack[-1] if trace_stack else None
         span_id = str(uuid.uuid4())
         self._trace_stack().append(span_id)
 

--- a/beeline/trace.py
+++ b/beeline/trace.py
@@ -18,16 +18,16 @@ class SynchronousTracer(Tracer):
         self._state = state
 
     @contextmanager
-    def __call__(self, name):
+    def __call__(self, name, trace_id=None, parent_id=None):
         try:
-            ev = self.new_traced_event(name)
+            ev = self.new_traced_event(name, trace_id, parent_id)
             self._state.add_event(ev)
             yield
         finally:
             ev = self._state.pop_event()
             self.send_traced_event(ev)
 
-    def new_traced_event(self, name):
+    def new_traced_event(self, name, trace_id, parent_id):
         '''
         Create an event decorated with trace IDs. Initiates a new trace if none
         is in progress, or appends the event to the trace stack.
@@ -36,7 +36,7 @@ class SynchronousTracer(Tracer):
         the trace will not work correctly
         '''
         ev = self._client.new_event()
-        trace_id, parent_id, span_id = self._state.start_trace()
+        trace_id, parent_id, span_id = self._state.start_trace(trace_id, parent_id)
         ev.add({
             'trace.trace_id': trace_id,
             'trace.parent_id': parent_id,


### PR DESCRIPTION
- Enables explicit setting of trace_id and parent_id in the SynchronousTracer
- This is not passed on to the `beeline.tracer` public API as we don't yet support people setting their own trace ids

Intended use is something like:

```
beeline.init(...)

def index(event, context):
    return wrap(_index, event, context)

def _index(event, context):
    current_time = datetime.datetime.now().time()
    body = {
        "message": "Hello, the current time is " + str(current_time)
    }

    with beeline.tracer("sleepytime"):
        time.sleep(0.500)

    response = {
        "statusCode": 200,
        "body": json.dumps(body)
    }

    return response
```