### PR TITLE
Refactor fragmented global state into Beeline object

### DIFF
--- a/beeline/internal.py
+++ b/beeline/internal.py
@@ -1,0 +1,18 @@
+import beeline
+
+# these are mostly convenience methods for safely calling beeline methods
+# even if the beeline hasn't been initialized
+def new_event(data=None, trace_name='', top_level=False):
+    bl = beeline.get_beeline()
+    if bl:
+        return bl.new_event(data, trace_name, top_level)
+
+def send_event():
+    bl = beeline.get_beeline()
+    if bl:
+        return bl.send_event()
+    
+def send_all():
+    bl = beeline.get_beeline()
+    if bl:
+        return bl.send_all()

--- a/beeline/middleware/awslambda/__init__.py
+++ b/beeline/middleware/awslambda/__init__.py
@@ -68,14 +68,14 @@ def beeline_wrapper(handler):
         global COLD_START
 
         # don't blow up the world if the beeline has not been initialized
-        if not beeline.g_client or not beeline.g_tracer:
+        if not beeline.get_beeline():
             return handler(event, context)
 
         try:
             # if we've passed a trace id from a previous lambda, it will
             # be here. We ignore context for now.
             trace_id, parent_id, _ = _get_trace_data(event)
-            with beeline.g_tracer(name=handler.__name__,
+            with beeline.tracer(name=handler.__name__,
                     trace_id=trace_id, parent_id=parent_id):
                 beeline.add({
                     "app.function_name": context.function_name,
@@ -94,6 +94,6 @@ def beeline_wrapper(handler):
             # This remains false for the lifetime of the module
             COLD_START = False
             # we have to flush events before the lambda returns
-            beeline.g_client.flush()
+            beeline.get_beeline().client.flush()
 
     return _beeline_wrapper

--- a/beeline/middleware/awslambda/test_awslambda.py
+++ b/beeline/middleware/awslambda/test_awslambda.py
@@ -43,8 +43,7 @@ class TestLambdaWrapper(unittest.TestCase):
     def test_basic_instrumentation(self):
         ''' ensure basic event fields get instrumented '''
         with patch('beeline.middleware.awslambda.beeline.add') as m_add,\
-                patch('beeline.middleware.awslambda.beeline.g_client'),\
-                patch('beeline.middleware.awslambda.beeline.g_tracer'),\
+                patch('beeline.middleware.awslambda.beeline._GBL'),\
                 patch('beeline.middleware.awslambda.COLD_START') as m_cold_start:
             m_event = Mock()
             m_context = Mock(function_name='fn', function_version="1.1.1",

--- a/beeline/middleware/bottle/__init__.py
+++ b/beeline/middleware/bottle/__init__.py
@@ -1,6 +1,5 @@
 import beeline
 
-
 class HoneyWSGIMiddleware(object):
 
     def __init__(self, app):
@@ -8,7 +7,7 @@ class HoneyWSGIMiddleware(object):
 
     def __call__(self, environ, start_response):
         trace_name = "bottle_http_%s" % environ['REQUEST_METHOD'].lower()
-        beeline._new_event(data={
+        beeline.internal.new_event(data={
             "type": "http_server",
             "request.host": environ['HTTP_HOST'],
             "request.method": environ['REQUEST_METHOD'],
@@ -22,7 +21,7 @@ class HoneyWSGIMiddleware(object):
 
         def _start_response(status, headers, *args):
             beeline.add_field("response.status_code", status)
-            beeline._send_event()
+            beeline.internal.send_event()
 
             return start_response(status, headers, *args)
 

--- a/beeline/middleware/django/__init__.py
+++ b/beeline/middleware/django/__init__.py
@@ -49,7 +49,7 @@ class HoneyMiddlewareBase(object):
         # the view (and later middleware) are called.
 
         trace_name = "django_http_%s" % request.method.lower()
-        beeline._new_event(data={
+        beeline.internal.new_event(data={
             "type": "http_server",
             "request.host": request.get_host(),
             "request.method": request.method,
@@ -70,7 +70,7 @@ class HoneyMiddlewareBase(object):
         # the view is called.
 
         beeline.add_field("response.status_code", response.status_code)
-        beeline._send_event()
+        beeline.internal.send_event()
 
         return response
 

--- a/beeline/middleware/flask/__init__.py
+++ b/beeline/middleware/flask/__init__.py
@@ -17,7 +17,7 @@ class HoneyMiddleware(object):
         if exception:
             beeline.add_field('request.error_detail', str(exception))
             beeline.add_field('request.error', str(type(exception)))
-            beeline._send_event()
+            beeline.internal.send_event()
 
 
 class HoneyWSGIMiddleware(object):
@@ -29,7 +29,7 @@ class HoneyWSGIMiddleware(object):
         trace_name = "flask_http_%s" % environ.get('REQUEST_METHOD', None)
         if trace_name is not None:
             trace_name = trace_name.lower()
-        beeline._new_event(data={
+        beeline.internal.new_event(data={
             "type": "http_server",
             "request.host": environ.get('HTTP_HOST', None),
             "request.method": environ.get('REQUEST_METHOD', None),
@@ -45,9 +45,9 @@ class HoneyWSGIMiddleware(object):
             status_code = int(status[0:4])
             beeline.add_field("response.status_code", status_code)
             if status_code != 500:
-                beeline._send_event()
+                beeline.internal.send_event()
             elif status_code == 500 and not signals.signals_available:
-                beeline._send_event()
+                beeline.internal.send_event()
 
             return start_response(status, headers, *args)
 
@@ -82,7 +82,7 @@ class HoneyDBMiddleware(object):
                 param = param.isoformat()
             params.append(param)
 
-        beeline._new_event(data={
+        beeline.internal.new_event(data={
             "type": "db",
             "db.query": statement,
             "db.query_args": params,
@@ -101,8 +101,8 @@ class HoneyDBMiddleware(object):
             "db.last_insert_id": cursor.lastrowid,
             "db.rows_affected": cursor.rowcount,
         })
-        beeline._send_event()
+        beeline.internal.send_event()
 
     def handle_error(self, context):
         beeline.add_field("db.error", str(context.original_exception))
-        beeline._send_event()
+        beeline.internal.send_event()

--- a/beeline/test_beeline.py
+++ b/beeline/test_beeline.py
@@ -6,30 +6,30 @@ import libhoney
 
 class TestBeelineSendEvent(unittest.TestCase):
     def setUp(self):
-        self.m_client = patch('beeline.g_client').start()
-        self.m_state = patch('beeline.g_state').start()
-        self.m_tracer = patch('beeline.g_tracer').start()
+        self.m_gbl = patch('beeline._GBL').start()
 
     def tearDown(self):
-        self.m_client.stop()
-        self.m_state.stop()
-        self.m_tracer.stop()
+        self.m_gbl.stop()
 
     def test_send_event(self):
         ''' test correct behavior for send_event '''
         ev = Mock()
         delattr(ev, 'traced_event')
-        self.m_state.pop_event.return_value = ev
-        beeline._send_event()
-        self.m_state.pop_event.assert_called_once_with()
+        _beeline = beeline.Beeline()
+        _beeline.state = Mock()
+        _beeline.state.pop_event.return_value = ev
+        _beeline.send_event()
+        _beeline.state.pop_event.assert_called_once_with()
         ev.send.assert_called_once_with()
 
     def test_send_no_events(self):
         ''' ensure nothing crashes when we try to send with no events in the
         stack '''
-        self.m_state.pop_event.return_value = None
-        beeline._send_event()
-        self.m_state.pop_event.assert_called_once_with()
+        _beeline = beeline.Beeline()
+        _beeline.state = Mock()
+        _beeline.state.pop_event.return_value = None
+        _beeline.send_event()
+        _beeline.state.pop_event.assert_called_once_with()
 
     def send_traced_event(self):
         ''' test send_event behavior when event is traced '''
@@ -47,9 +47,11 @@ class TestBeelineSendEvent(unittest.TestCase):
         delattr(ev1, 'traced_event')
         delattr(ev2, 'traced_event')
         delattr(ev3, 'traced_event')
-        self.m_state.pop_event.side_effect = [ev1, ev2, ev3, None]
+        _beeline = beeline.Beeline()
+        _beeline.state = Mock()
+        _beeline.state.pop_event.side_effect = [ev1, ev2, ev3, None]
 
-        beeline._send_all()
+        _beeline.send_all()
 
         ev1.send.assert_called_once_with()
         ev2.send.assert_called_once_with()
@@ -59,84 +61,90 @@ class TestBeelineSendEvent(unittest.TestCase):
         ''' ensure send works when no hooks defined '''
         ev = Mock()
         delattr(ev, 'traced_event')
-        beeline._run_hooks_and_send(ev)
+        _beeline = beeline.Beeline()
+        _beeline.tracer_impl = Mock()
+        _beeline._run_hooks_and_send(ev)
 
         # no hooks, not a traced event - call send
         ev.send.assert_called_once_with()
         ev.send_presampled.assert_not_called()
-        self.m_tracer.send_traced_event.assert_not_called()
+        _beeline.tracer_impl.send_traced_event.assert_not_called()
 
         # traced_event is an implicit attribute on Mock, so send_traced_event
         # should be called
         traced_ev = Mock()
-        beeline._run_hooks_and_send(traced_ev)
-        self.m_tracer.send_traced_event.assert_called_once_with(traced_ev, presampled=False)
+        _beeline._run_hooks_and_send(traced_ev)
+        _beeline.tracer_impl.send_traced_event.assert_called_once_with(traced_ev, presampled=False)
 
     def test_run_hooks_and_send_sampler(self):
         ''' ensure send works with a sampler hook defined '''
-        with patch('beeline.g_sampler_hook') as m_sampler:
-            def _sampler_drop_all(fields):
-                return False, 0
-            m_sampler.side_effect = _sampler_drop_all
-            ev = Mock()
-            # non-traced event
-            delattr(ev, 'traced_event')
+        def _sampler_drop_all(fields):
+            return False, 0
+        m_sampler_hook = Mock()
+        m_sampler_hook.side_effect = _sampler_drop_all
+        _beeline = beeline.Beeline(sampler_hook=m_sampler_hook)
+        _beeline.tracer_impl = Mock()
+        ev = Mock()
+        # non-traced event
+        delattr(ev, 'traced_event')
 
-            beeline._run_hooks_and_send(ev)
-            m_sampler.assert_called_once_with(ev.fields())
-            ev.send_presampled.assert_not_called()
-            ev.send.assert_not_called()
+        _beeline._run_hooks_and_send(ev)
+        m_sampler_hook.assert_called_once_with(ev.fields())
+        ev.send_presampled.assert_not_called()
+        ev.send.assert_not_called()
 
-            def _sampler_drop_none(fields):
-                return True, 100
+        def _sampler_drop_none(fields):
+            return True, 100
 
-            ev = Mock()
-            # non-traced event
-            delattr(ev, 'traced_event')
-            m_sampler.reset_mock()
+        ev = Mock()
+        # non-traced event
+        delattr(ev, 'traced_event')
+        m_sampler_hook.reset_mock()
 
-            m_sampler.side_effect = _sampler_drop_none
+        m_sampler_hook.side_effect = _sampler_drop_none
 
-            beeline._run_hooks_and_send(ev)
-            m_sampler.assert_called_once_with(ev.fields())
-            self.assertEqual(ev.sample_rate, 100)
-            ev.send_presampled.assert_called_once_with()
-            ev.send.assert_not_called()
+        _beeline._run_hooks_and_send(ev)
+        m_sampler_hook.assert_called_once_with(ev.fields())
+        self.assertEqual(ev.sample_rate, 100)
+        ev.send_presampled.assert_called_once_with()
+        ev.send.assert_not_called()
 
-            # traced event
-            ev = Mock()
-            m_sampler.reset_mock()
+        # traced event
+        ev = Mock()
+        m_sampler_hook.reset_mock()
 
-            beeline._run_hooks_and_send(ev)
-            m_sampler.assert_called_once_with(ev.fields())
-            self.assertEqual(ev.sample_rate, 100)
-            self.m_tracer.send_traced_event.assert_called_once_with(ev, presampled=True)
-            ev.send_presampled.assert_not_called()
-            ev.send.assert_not_called()
+        _beeline._run_hooks_and_send(ev)
+        m_sampler_hook.assert_called_once_with(ev.fields())
+        self.assertEqual(ev.sample_rate, 100)
+        _beeline.tracer_impl.send_traced_event.assert_called_once_with(ev, presampled=True)
+        ev.send_presampled.assert_not_called()
+        ev.send.assert_not_called()
 
     def test_run_hooks_and_send_presend_hook(self):
         ''' ensure send works when presend hook is defined '''
-        with patch('beeline.g_presend_hook') as m_presend:
-            def _presend_hook(fields):
-                fields["thing i want"] = "put it there"
-                del fields["thing i don't want"]
-            m_presend.side_effect = _presend_hook
+        def _presend_hook(fields):
+            fields["thing i want"] = "put it there"
+            del fields["thing i don't want"]
+        m_presend_hook = Mock()
+        m_presend_hook.side_effect = _presend_hook
+        _beeline = beeline.Beeline(presend_hook=m_presend_hook)
+        _beeline.tracer_impl = Mock()
 
-            ev = Mock()
-            delattr(ev, 'traced_event')
-            ev.fields.return_value = {
-                "thing i don't want": "get it out of here",
+        ev = Mock()
+        delattr(ev, 'traced_event')
+        ev.fields.return_value = {
+            "thing i don't want": "get it out of here",
+            "happy data": "so happy",
+        }
+
+        _beeline._run_hooks_and_send(ev)
+        _beeline.tracer_impl.send_traced_event.assert_not_called()
+        ev.send_presampled.assert_not_called()
+        ev.send.assert_called_once_with()
+        self.assertDictEqual(
+            ev.fields(),
+            {
+                "thing i want": "put it there",
                 "happy data": "so happy",
-            }
-
-            beeline._run_hooks_and_send(ev)
-            self.m_tracer.send_traced_event.assert_not_called()
-            ev.send_presampled.assert_not_called()
-            ev.send.assert_called_once_with()
-            self.assertDictEqual(
-                ev.fields(),
-                {
-                    "thing i want": "put it there",
-                    "happy data": "so happy",
-                },
-            )
+            },
+        )


### PR DESCRIPTION
We currently use a number of scattered global variables to implement the beeline. Adding new things is awkward because you have to reach into the beeline module's global state from other modules, and you can't always trust that things are initialized correctly. So to make this easier to maintain going forward I am wrapping up global state into a single object. Other modules can use the public method `get_beeline` to get the global beeline, or create an object of their own if necessary.

Also moved some internal methods to a new `internal` module to discourage users from using them (had seen this before with `_new_event` and `_send_event`)