### PR TITLE
[tracing] Add public trace API

### DIFF
--- a/beeline/test_trace.py
+++ b/beeline/test_trace.py
@@ -1,8 +1,14 @@
-from mock import Mock
+from mock import Mock, call, patch
+import datetime
 import unittest
 import uuid
 
-from beeline.trace import _should_sample, SynchronousTracer
+from libhoney import Event
+
+from beeline.trace import (
+    _should_sample, SynchronousTracer, marshal_trace_context,
+    unmarshal_trace_context, Span
+)
 
 class TestTraceSampling(unittest.TestCase):
     def test_deterministic(self):
@@ -42,10 +48,297 @@ class TestSynchronousTracer(unittest.TestCase):
         raised inside the context manager '''
         m_client, m_state = Mock(), Mock()
         tracer = SynchronousTracer(m_client, m_state)
+        tracer.start_trace = Mock()
+        mock_span = Mock()
+        tracer.start_trace.return_value = mock_span
+        tracer.finish_trace = Mock()
         try:
             with tracer('foo'):
                 raise Exception('boom!')
         except Exception:
             pass
-        
-        m_state.pop_event.assert_called_once_with()
+        tracer.finish_trace.assert_called_once_with(mock_span)
+
+    def test_trace_context_manager_starts_span_if_trace_active(self):
+        m_client, m_state = Mock(), Mock()
+        tracer = SynchronousTracer(m_client, m_state)
+        tracer.start_span = Mock()
+        mock_span = Mock()
+        tracer.start_span.return_value = mock_span
+        tracer.finish_span = Mock()
+
+        with tracer('foo'):
+            pass
+
+        tracer.start_span.assert_called_once_with(context={'name': 'foo'}, parent_id=None)
+        tracer.finish_span.assert_called_once_with(mock_span)
+
+    def test_start_trace(self):
+        m_client, m_state = Mock(), Mock()
+        tracer = SynchronousTracer(m_client, m_state)
+
+        span = tracer.start_trace(context={'big': 'important_stuff'})
+        self.assertIsInstance(span.event.start_time, datetime.datetime)
+        # make sure our context got passed on to the event
+        m_client.new_event.return_value.add.assert_has_calls([
+            call(data={'big': 'important_stuff'}),
+            call(data={
+                'trace.trace_id': span.trace_id,
+                'trace.parent_id': span.parent_id,
+                'trace.span_id': span.id,
+            }),
+        ])
+        self.assertEqual(tracer._state.stack[0], span)
+        # ensure we started a trace by setting a trace_id
+        self.assertIsNotNone(tracer._state.trace_id)
+
+    def test_start_span(self):
+        m_client, m_state = Mock(), Mock()
+        tracer = SynchronousTracer(m_client, m_state)
+
+        span = tracer.start_trace(context={'big': 'important_stuff'})
+        # make sure this is the only event in the stack
+        self.assertEqual(tracer._state.stack[0], span)
+        self.assertEqual(len(tracer._state.stack), 1)
+
+        span2 = tracer.start_span(context={'more': 'important_stuff'})
+        # should still have the root span as the first item in the stack
+        self.assertEqual(tracer._state.stack[0], span)
+        self.assertEqual(tracer._state.stack[-1], span2)
+        # should have the first span id as its parent
+        # should share the same trace id
+        self.assertEqual(span.trace_id, span2.trace_id)
+        self.assertEqual(span.id, span2.parent_id)
+        # trace id should match what the tracer has
+        self.assertEqual(span.trace_id, tracer._state.trace_id)
+        m_client.new_event.return_value.add.assert_has_calls([
+            call(data={'more': 'important_stuff'}),
+            call(data={
+                'trace.trace_id': span2.trace_id,
+                'trace.parent_id': span2.parent_id,
+                'trace.span_id': span2.id,
+            }),
+        ])
+
+    def test_start_span_returns_none_if_no_trace(self):
+        m_client, m_state = Mock(), Mock()
+        tracer = SynchronousTracer(m_client, m_state)
+
+        span = tracer.start_span(context={'more': 'important_stuff'})
+        # should still have the root span as the first item in the stack
+        self.assertIsNone(span)
+        self.assertEqual(len(tracer._state.stack), 0)
+
+    def test_finish_trace(self):
+        # implicitly tests finish_span
+        m_client, m_state = Mock(), Mock()
+        # these values are used before sending
+        m_client.new_event.return_value.start_time = datetime.datetime.now()
+        m_client.new_event.return_value.sample_rate = 1
+        tracer = SynchronousTracer(m_client, m_state)
+
+        span = tracer.start_trace(context={'big': 'important_stuff'})
+        self.assertEqual(tracer._state.stack[0], span)
+
+        tracer.finish_trace(span)
+        # ensure the event is sent
+        span.event.send_presampled.assert_called_once_with()
+        # ensure the stack is clean
+        self.assertEqual(len(tracer._state.stack), 0)
+        # ensure the trace_id is reset to None
+        self.assertIsNone(tracer._state.trace_id)
+
+    def test_start_trace_with_trace_id_set(self):
+        m_client, m_state = Mock(), Mock()
+        tracer = SynchronousTracer(m_client, m_state)
+
+        span = tracer.start_trace(trace_id='123456', parent_span_id='999999')
+        self.assertEqual(span.trace_id, '123456')
+        self.assertEqual(span.parent_id, '999999')
+        self.assertEqual(tracer._state.trace_id, '123456')
+
+        m_client.new_event.return_value.add.assert_has_calls([
+            call(data={
+                'trace.trace_id': span.trace_id,
+                'trace.parent_id': span.parent_id,
+                'trace.span_id': span.id,
+            }),
+        ])
+
+    def test_add_custom_context_propagates(self):
+        m_client, m_state = Mock(), Mock()
+        tracer = SynchronousTracer(m_client, m_state)
+
+        span = tracer.start_trace(context={'big': 'important_stuff'})
+        # make sure this is the only event in the stack
+        self.assertEqual(tracer._state.stack[0], span)
+        self.assertEqual(len(tracer._state.stack), 1)
+
+        m_client.new_event.reset_mock()
+
+        tracer.add_custom_context('another', 'important_thing')
+        tracer.add_custom_context('wide', 'events_are_great')
+
+        span2 = tracer.start_span(context={'more': 'important_stuff'})
+        # should still have the root span as the first item in the stack
+        self.assertEqual(tracer._state.stack[0], span)
+        self.assertEqual(tracer._state.stack[-1], span2)
+        # should have the first span id as its parent
+        # should share the same trace id
+        self.assertEqual(span.trace_id, span2.trace_id)
+        self.assertEqual(span.id, span2.parent_id)
+        # trace id should match what the tracer has
+        self.assertEqual(span.trace_id, tracer._state.trace_id)
+        m_client.new_event.assert_called_once_with(data={
+                'app.another': 'important_thing',
+                'app.wide': 'events_are_great'
+        })
+        m_client.new_event.return_value.add.assert_has_calls([
+            call(data={'more': 'important_stuff'}),
+            call(data={
+                'trace.trace_id': span2.trace_id,
+                'trace.parent_id': span2.parent_id,
+                'trace.span_id': span2.id,
+            }),
+        ])
+
+        m_client.new_event.reset_mock()
+        # swap out some custom context fields
+        tracer.add_custom_context('more', 'data!')
+        tracer.remove_custom_context('another')
+
+        span3 = tracer.start_span(context={'more': 'important_stuff'})
+        self.assertEqual(tracer._state.stack[0], span)
+        self.assertEqual(tracer._state.stack[1], span2)
+        self.assertEqual(tracer._state.stack[-1], span3)
+        # should have the second span id as its parent
+        # should share the same trace id
+        self.assertEqual(span.trace_id, span3.trace_id)
+        self.assertEqual(span2.id, span3.parent_id)
+        m_client.new_event.assert_called_once_with(data={
+                'app.wide': 'events_are_great',
+                'app.more': 'data!',
+        })
+
+        def test_get_active_span(self):
+            m_client, m_state = Mock(), Mock()
+            tracer = SynchronousTracer(m_client, m_state)
+            span = tracer.start_trace()
+            self.assertEquals(tracer.get_active_span(), span.id)
+
+    def test_run_hooks_and_send_no_hooks(self):
+        ''' ensure send works when no hooks defined '''
+        m_client, m_state = Mock(), Mock()
+        # these values are used before sending
+        tracer = SynchronousTracer(m_client, m_state)
+        m_span = Mock()
+
+        with patch('beeline.trace._should_sample') as m_sample_fn:
+            m_sample_fn.return_value = True
+            tracer._run_hooks_and_send(m_span)
+
+        # no hooks - trace's _should_sample is rigged to always return true, so we
+        # always call send_presampled
+        # send should never be called because at a minimum we always do deterministic
+        # sampling
+        m_span.event.send.assert_not_called()
+        m_span.event.send_presampled.assert_called_once_with()
+
+    def test_run_hooks_and_send_sampler(self):
+        ''' ensure send works with a sampler hook defined '''
+        m_client, m_state = Mock(), Mock()
+        # these values are used before sending
+        tracer = SynchronousTracer(m_client, m_state)
+        m_span = Mock()
+
+        def _sampler_drop_all(fields):
+            return False, 0
+
+        tracer.register_hooks(sampler=_sampler_drop_all)
+
+        with patch('beeline.trace._should_sample') as m_sample_fn:
+            m_sample_fn.return_value = True
+            tracer._run_hooks_and_send(m_span)
+
+        # sampler ensures we drop everything
+        m_span.event.send.assert_not_called()
+        m_span.event.send_presampled.assert_not_called()
+
+        def _sampler_drop_none(fields):
+            return True, 100
+
+        tracer.register_hooks(sampler=_sampler_drop_none)
+        m_span.reset_mock()
+
+        with patch('beeline.trace._should_sample') as m_sample_fn:
+            m_sample_fn.return_value = True
+            tracer._run_hooks_and_send(m_span)
+
+        # sampler drops nothing, _should_sample rigged to always return true so
+        # we always call send_presampled
+        m_span.event.send.assert_not_called()
+        m_span.event.send_presampled.assert_called_once_with()
+        # ensure event is updated with new sample rate
+        self.assertEqual(m_span.event.sample_rate, 100)
+
+    def test_run_hooks_and_send_presend_hook(self):
+        ''' ensure send works when presend hook is defined '''
+        m_client, m_state = Mock(), Mock()
+        # these values are used before sending
+        tracer = SynchronousTracer(m_client, m_state)
+        m_span = Mock()
+
+        def _presend_hook(fields):
+            fields["thing i want"] = "put it there"
+            del fields["thing i don't want"]
+
+        m_span = Mock()
+        m_span.event.fields.return_value = {
+            "thing i don't want": "get it out of here",
+            "happy data": "so happy",
+        }
+
+        tracer.register_hooks(presend=_presend_hook)
+
+        with patch('beeline.trace._should_sample') as m_sample_fn:
+            m_sample_fn.return_value = True
+            tracer._run_hooks_and_send(m_span)
+
+        m_span.event.send_presampled.assert_called_once_with()
+        self.assertDictEqual(
+            m_span.event.fields(),
+            {
+                "thing i want": "put it there",
+                "happy data": "so happy",
+            },
+        )
+
+
+class TestTraceContext(unittest.TestCase):
+    def test_marshal_trace_context(self):
+        trace_id = "123456"
+        parent_id = "654321"
+        custom_context = {"i": "like", "to": "trace"}
+
+        trace_context = marshal_trace_context(trace_id, parent_id, custom_context)
+
+        trace_id_u, parent_id_u, custom_context_u = unmarshal_trace_context(trace_context)
+        self.assertEqual(trace_id_u, trace_id, "unmarshaled trace id should match original")
+        self.assertEqual(parent_id_u, parent_id, "unmarshaled parent id should match original")
+        self.assertDictEqual(custom_context_u, custom_context, "unmarshaled custom context should match original")
+
+
+class TestSpan(unittest.TestCase):
+    def test_span_context(self):
+        ev = Event()
+        span = Span('', '', '', ev)
+        span.add_context_field("some", "value")
+        span.add_context({"another": "value"})
+        self.assertDictEqual({
+            "some": "value",
+            "another": "value"
+        }, ev.fields())
+        span.remove_context_field("another")
+        self.assertDictEqual({
+            "some": "value",
+        }, ev.fields())

--- a/beeline/trace.py
+++ b/beeline/trace.py
@@ -1,7 +1,12 @@
+import base64
 import datetime
 import hashlib
+import json
 import math
 import struct
+import threading
+import uuid
+from functools import wraps
 
 from contextlib import contextmanager
 
@@ -9,29 +14,190 @@ from beeline.internal import log
 
 MAX_INT32 = math.pow(2, 32) - 1
 
+def init_state(f):
+    ''' Ensure thread local state is initialized in each thread '''
+    @wraps(f)
+    def d(self, *args, **kwargs):
+        if not hasattr(self._state, 'trace_id'):
+            self._state.trace_id = None
+            self._state.stack = []
+            self._state.custom_context = {}
+
+        return f(self, *args, **kwargs)
+    return d
 
 class Tracer(object):
     pass
 
-
 class SynchronousTracer(Tracer):
     def __init__(self, client, state):
         self._client = client
-        self._state = state
+        self._state = threading.local()
+        self._state.trace_id = None
+        self._state.stack = []
+        self._state.custom_context = {}
+
+        self.presend_hook = None
+        self.sampler_hook = None
+
+        self._deprecated_state = state
 
     @contextmanager
     def __call__(self, name, trace_id=None, parent_id=None):
         try:
-            ev = self.new_traced_event(name, trace_id, parent_id)
-            self._state.add_event(ev)
+            span = None
+            is_trace = False
+            if self.get_active_trace_id():
+                span = self.start_span(context={'name': name})
+                log('tracer context manager started new span, id = %s',
+                    span.id)
+            else:
+                is_trace = True
+                span = self.start_trace(context={'name': name})
+                log('tracer context manager started new trace, id = %s',
+                    span.trace_id)
             yield
         finally:
-            ev = self._state.pop_event()
-            log("enqueuing traced event ev = %s", ev.fields())
-            self.send_traced_event(ev)
+            if is_trace:
+                log('tracer context manager ending trace, id = %s',
+                    span.trace_id)
+                self.finish_trace(span)
+            else:
+                log('tracer context manager ending span, id = %s',
+                    span.id)
+                self.finish_span(span)
+
+    @init_state
+    def start_trace(self, context=None, trace_id=None, parent_span_id=None):
+        if trace_id:
+            if self._state.trace_id:
+                log('warning: start_trace got explicit trace_id but we are already in a trace. '
+                    'starting new trace with id = %s', trace_id)
+            self._state.trace_id = trace_id
+        else:
+            self._state.trace_id = str(uuid.uuid4())
+
+        # reset our stack and context on new traces
+        self._state.stack = []
+        self._state.custom_context = {}
+
+        # start the root span
+        return self.start_span(context=context, parent_id=parent_span_id)
+
+    @init_state
+    def start_span(self, context=None, parent_id=None):
+        if not self._state.trace_id:
+            log('start_span called but no trace is active')
+            return None
+
+        span_id = str(uuid.uuid4())
+        if parent_id:
+            parent_span_id = parent_id
+        else:
+            parent_span_id = self._state.stack[-1].id if self._state.stack else None
+        ev = self._client.new_event(data=self._state.custom_context)
+        if context:
+            ev.add(data=context)
+
+        ev.add(data={
+            'trace.trace_id': self._state.trace_id,
+            'trace.parent_id': parent_span_id,
+            'trace.span_id': span_id,
+        })
+        is_root = len(self._state.stack) == 0
+        span = Span(trace_id=self._state.trace_id, parent_id=parent_span_id,
+                    id=span_id, event=ev, is_root=is_root)
+        self._state.stack.append(span)
+
+        return span
+
+    @init_state
+    def finish_span(self, span):
+        # send the span's event. Even if the stack is in an unhealthy state,
+        # it's probably better to send event data than not
+        if span.event:
+            duration = datetime.datetime.now() - span.event.start_time
+            duration_ms = duration.total_seconds() * 1000.0
+            span.event.add_field('duration_ms', duration_ms)
+
+            self._run_hooks_and_send(span)
+        else:
+            log('warning: span has no event, was it initialized correctly?')
+
+        if span.trace_id != self._state.trace_id:
+            log('warning: finished span called for span in inactive trace. '
+                'current trace_id = %s, span trace_id = %s', self._state.trace_id, span.trace_id)
+            return
+
+        if not self._state.stack:
+            log('warning: finish span called but stack is empty')
+            return
+
+        if self._state.stack[-1].id != span.id:
+            log('warning: finished span is not the currently active span')
+            return
+
+        self._state.stack.pop()
+
+    @init_state
+    def finish_trace(self, span):
+        self.finish_span(span)
+        self._state.trace_id = None
+
+    @init_state
+    def get_active_trace_id(self):
+        return self._state.trace_id
+
+    @init_state
+    def get_active_span(self):
+        if self._state.stack:
+            return self._state.stack[-1]
+
+    def add_context_field(self, name, value):
+        span = self.get_active_span()
+        if span:
+            span.add_context_field(name=name, value=value)
+
+    def add_context(self, data):
+        span = self.get_active_span()
+        if span:
+            span.add_context(data=data)
+
+    def remove_context_field(self, name):
+        span = self.get_active_span()
+        if span:
+            span.remove_context_field(name=name)
+
+    @init_state
+    def add_custom_context(self, name, value):
+        # prefix with app to avoid key conflicts
+        key = "app.%s" % name
+        self._state.custom_context[key] = value
+        # also add to current span
+        self.add_context_field(key, value)
+
+    @init_state
+    def remove_custom_context(self, name):
+        key = "app.%s" % name
+        if key in self._state.custom_context:
+            del self._state.custom_context[key]
+
+    @init_state
+    def marshal_trace_context(self):
+        if not self._state.trace_id:
+            log('warning: marshal_trace_context called, but no active trace')
+            return
+
+        return marshal_trace_context(
+            self._state.trace_id,
+            self._state.stack[-1],
+            self._state.custom_context
+        )
 
     def new_traced_event(self, name, trace_id=None, parent_id=None):
         '''
+        DEPRECATED - to be removed in a future release
+
         Create an event decorated with trace IDs. Initiates a new trace if none
         is in progress, or appends the event to the trace stack.
 
@@ -39,7 +205,7 @@ class SynchronousTracer(Tracer):
         the trace will not work correctly
         '''
         ev = self._client.new_event()
-        trace_id, parent_id, span_id = self._state.start_trace(
+        trace_id, parent_id, span_id = self.deprecated_state.start_trace(
             trace_id, parent_id)
         ev.add({
             'trace.trace_id': trace_id,
@@ -53,7 +219,10 @@ class SynchronousTracer(Tracer):
         return ev
 
     def send_traced_event(self, ev, presampled=False):
-        ''' Applies deterministic sampling to the event before sending. This allows
+        '''
+        DEPRECATED - to be removed in a future release
+
+        Applies deterministic sampling to the event before sending. This allows
         us to sample entire traces '''
         # we shouldn't get called for non-trace events, so do nothing.
         if not hasattr(ev, 'traced_event'):
@@ -72,8 +241,62 @@ class SynchronousTracer(Tracer):
         else:
             ev.send()
 
-        self._state.end_trace()
+        self._deprecated_state.end_trace()
 
+    def register_hooks(self, presend=None, sampler=None):
+        self.presend_hook = presend
+        self.sampler_hook = sampler
+
+    def _run_hooks_and_send(self, span):
+        ''' internal - run any defined hooks on the event and send
+
+        kind of hacky: we fetch the hooks from the beeline, but they are only
+        used here. Pass them to the tracer implementation?
+        '''
+        presampled = False
+        if self.sampler_hook:
+            log("executing sampler hook on event ev = %s", span.event.fields())
+            keep, new_rate = self.sampler_hook(span.event.fields())
+            if not keep:
+                log("skipping event due to sampler hook sampling ev = %s", span.event.fields())
+                return
+            span.event.sample_rate = new_rate
+            presampled = True
+
+        if self.presend_hook:
+            log("executing presend hook on event ev = %s", span.event.fields())
+            self.presend_hook(span.event.fields())
+
+        if presampled:
+            log("enqueuing presampled event ev = %s", span.event.fields())
+            span.event.send_presampled()
+        elif _should_sample(span.trace_id, span.event.sample_rate):
+            # if our sampler hook wasn't used, use deterministic sampling
+            span.event.send_presampled()
+
+class Span(object):
+    ''' Span represents an active span. Should not be initialized directly, but
+    through a Tracer object's `start_span` method. '''
+    def __init__(self, trace_id, parent_id, id, event, is_root=False):
+        self.trace_id = trace_id
+        self.parent_id = parent_id
+        self.id = id
+        self.event = event
+        self.event.start_time = datetime.datetime.now()
+        self._is_root = is_root
+
+    def add_context_field(self, name, value):
+        self.event.add_field(name, value)
+
+    def add_context(self, data):
+        self.event.add(data)
+
+    def remove_context_field(self, name):
+        if name in self.event.fields():
+            del self.event.fields()[name]
+
+    def is_root(self):
+        return self._is_root
 
 def _should_sample(trace_id, sample_rate):
     sample_upper_bound = MAX_INT32 / sample_rate
@@ -85,3 +308,38 @@ def _should_sample(trace_id, sample_rate):
     if value < sample_upper_bound:
         return True
     return False
+
+def marshal_trace_context(trace_id, parent_id, context):
+    version = 1
+    custom_context = base64.b64encode(json.dumps(context).encode()).decode()
+    trace_context = "{};trace_id={},parent_id={},context={}".format(
+        version, trace_id, parent_id, custom_context
+    )
+
+    return trace_context
+
+def unmarshal_trace_context(trace_context):
+    # the first value is the trace payload version
+    # at this time there is only one version, but we should warn
+    # if another version comes through
+    version, data = trace_context.split(';', 1)
+    if version != "1":
+        log('warning: trace_context version %s is unsupported', version)
+        return None, None, None
+
+    kv_pairs = data.split(',')
+
+    trace_id, parent_id, context = None, None, None
+    # For version 1, we expect three kv pairs. If there's anything else, the
+    # payload is malformed and we do nothing.
+    if len(kv_pairs) == 3:
+        for pair in kv_pairs:
+            k, v = pair.split('=', 1)
+            if k == 'trace_id':
+                trace_id = v
+            elif k == 'parent_id':
+                parent_id = v
+            elif k == 'context':
+                context = json.loads(base64.b64decode(v.encode()).decode())
+
+    return trace_id, parent_id, context


### PR DESCRIPTION
Below paves the way for easier implementation of inter-service tracing and auto-instrumentation. I will follow up with another diff based on this to add the required plumbing for our middleware, and also add instrumentation for the `requests` lib as a starter for automagic propagation.

Based heavily off of https://github.com/honeycombio/beeline-nodejs/blob/master/docs/API.md - provide a public API for traces including:

starting/finishing spans
starting/finishing traces
marshaling/unmarshaling trace context
adding custom context

Does away with the dual event and trace stacks - everything is a span now, so there's one stack of spans to keep track of. There are some deprecated functions kept around that are based on the old state model, because it's possible someone out there is using them, but it's unlikely.

The earlier events API is now implemented with the tracer based on spans. `beeline.new_event` and `beeline.send_event` will work, but they are creating a trace/span under the hood.