### PR TITLE
[patch] add requests instrumentation

### DIFF
--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -241,6 +241,7 @@ def init(writekey='', dataset='', service_name='', state_manager=None, tracer=No
         writekey=writekey, dataset=dataset, sample_rate=sample_rate,
         api_host=api_host, transmission_impl=transmission_impl,
         debug=debug, presend_hook=presend_hook, sampler_hook=sampler_hook,
+        service_name=service_name,
         # since we've simplified the init function signature a bit,
         # pass on other args for backwards compatibility
         *args, **kwargs

--- a/beeline/patch/requests.py
+++ b/beeline/patch/requests.py
@@ -1,0 +1,22 @@
+from wrapt import wrap_function_wrapper
+import requests
+# needed for pyflakes
+assert requests
+import beeline
+
+def request(_request, instance, args, kwargs):
+    try:
+        b = beeline.get_beeline()
+        if b:
+            context = b.tracer_impl.marshal_trace_context()
+            if context:
+                b.log("requests lib - adding trace context to outbound request: %s", context)
+                instance.headers['X-Honeycomb-Trace'] = context
+            else:
+                b.log("requests lib - no trace context found")
+    except Exception:
+        pass
+    finally:
+        _request(*args, **kwargs)
+
+wrap_function_wrapper('requests.sessions', 'Session.request', request)

--- a/beeline/trace.py
+++ b/beeline/trace.py
@@ -188,7 +188,7 @@ class SynchronousTracer(Tracer):
 
         return marshal_trace_context(
             self._state.trace_id,
-            self._state.stack[-1],
+            self._state.stack[-1].id,
             self._state.custom_context
         )
 


### PR DESCRIPTION
Depends on https://github.com/honeycombio/beeline-python/pull/27

Adds a simple wrapper around `requests.sessions.Session.request` - will fetch the current thread's trace context - if it exists - marshaling it into a header called `X-Honeycomb-Trace`.

To use:
```
import beeline
from beeline.patch import requests
import requests

beeline.init(...)

requests.get()
requests.post()

```