### PR TITLE
[api] add marshal_trace_context to top-level API

### DIFF
--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -427,6 +427,24 @@ def finish_span(span):
     if _GBL:
         _GBL.tracer_impl.finish_span(span=span)
 
+def marshal_trace_context():
+    '''
+    Returns a serialized form of the current trace context (including the trace
+    id and the current span), encoded as a string. You can use this to propagate
+    trace context to other services.
+
+    Example:
+
+    ```
+    trace_context = beeline.marshal_trace_context()
+    headers = {'X-Honeycomb-Trace': trace_context}
+    requests.get("http://...", headers=headers)
+    ```
+    '''
+    if _GBL:
+        return _GBL.tracer_impl.marshal_trace_context()
+
+
 def new_event(data=None, trace_name=''):
     ''' DEPRECATED: Helper method that wraps `start_trace` and 
     `start_span`. It is better to use these methods as it provides

--- a/beeline/middleware/awslambda/test_awslambda.py
+++ b/beeline/middleware/awslambda/test_awslambda.py
@@ -34,11 +34,13 @@ class TestLambdaWrapper(unittest.TestCase):
         ''' ensure that the wrapper doesn't break anything if used before
         beeline.init is called
         '''
-        @awslambda.beeline_wrapper
-        def foo(event, context):
-            return 1
+        with patch('beeline.get_beeline') as p:
+            p.return_value = None
+            @awslambda.beeline_wrapper
+            def foo(event, context):
+                return 1
 
-        self.assertEqual(foo(None, None), 1)
+            self.assertEqual(foo(None, None), 1)
 
     def test_basic_instrumentation(self):
         ''' ensure basic event fields get instrumented '''

--- a/beeline/test_beeline.py
+++ b/beeline/test_beeline.py
@@ -152,3 +152,9 @@ class TestBeeline(unittest.TestCase):
         self.m_gbl.tracer_impl.start_trace.return_value = 'wooimatrace'
         val = beeline.start_trace()
         self.assertEqual(val, 'wooimatrace')
+
+    def test_marshal_trace_context_returns_value(self):
+        ''' ensure the top-level definition of marshal_trace_context returns a value '''
+        self.m_gbl.tracer_impl.marshal_trace_context.return_value = 'asdf'
+        val = beeline.marshal_trace_context()
+        self.assertEqual(val, 'asdf')

--- a/beeline/version.py
+++ b/beeline/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.0.0'
+VERSION = '2.1.0'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 setup(
     python_requires='>=2.7',
     name='honeycomb-beeline',
-    version='2.0.0',
+    version='2.1.0',
     description='Honeycomb library for easy instrumentation',
     url='https://github.com/honeycombio/beeline-python',
     author='Honeycomb.io',


### PR DESCRIPTION
Accidentally left this out in 2.0.