### PR TITLE
Fix crash in contextmanager if span is None

### DIFF
--- a/beeline/test_trace.py
+++ b/beeline/test_trace.py
@@ -332,6 +332,18 @@ class TestSynchronousTracer(unittest.TestCase):
         # ensure we only added fields b and c and did not try to overwrite a
         self.assertDictContainsSubset({'app.a': 1, 'app.b': 2, 'app.c': 3}, m_span.event.fields())
 
+    def test_trace_context_manager_does_not_crash_if_span_is_none(self):
+        m_client = Mock()
+        tracer = SynchronousTracer(m_client)
+        tracer.start_span = Mock()
+        tracer.start_span.return_value = None
+        tracer.finish_span = Mock()
+
+        with tracer('foo'):
+            pass
+
+        tracer.start_span.assert_called_once_with(context={'name': 'foo'}, parent_id=None)
+
 class TestTraceContext(unittest.TestCase):
     def test_marshal_trace_context(self):
         trace_id = "123456"

--- a/beeline/version.py
+++ b/beeline/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.4.0'
+VERSION = '2.4.1'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 setup(
     python_requires='>=2.7',
     name='honeycomb-beeline',
-    version='2.4.0',
+    version='2.4.1',
     description='Honeycomb library for easy instrumentation',
     url='https://github.com/honeycombio/beeline-python',
     author='Honeycomb.io',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     tests_require=[
         'mock',
         'flask',
-        'tornado',
+        'tornado==5',
         'django<2; python_version == "2.7"',
         'django>=2; python_version >= "3.0"',
     ],


### PR DESCRIPTION
It's possible for the context manager to be interrupted before `span` is set (i.e. through an exception). Put defenses in to prevent span attributes from being accessed if span is never set.