### PR TITLE
[trace] tracer context manager should yield the span object

### DIFF
--- a/beeline/test_trace.py
+++ b/beeline/test_trace.py
@@ -69,8 +69,8 @@ class TestSynchronousTracer(unittest.TestCase):
         tracer.start_span.return_value = mock_span
         tracer.finish_span = Mock()
 
-        with tracer('foo'):
-            pass
+        with tracer('foo') as span:
+            self.assertEqual(span, mock_span, 'tracer context manager should yield the span')
 
         tracer.start_span.assert_called_once_with(context={'name': 'foo'}, parent_id=None)
         tracer.start_trace.assert_not_called()

--- a/beeline/trace.py
+++ b/beeline/trace.py
@@ -51,7 +51,7 @@ class SynchronousTracer(Tracer):
                 if span:
                     log('tracer context manager started new trace, id = %s',
                         span.trace_id)
-            yield
+            yield span
         except Exception as e:
             if span:
                 span.add_context({

--- a/beeline/version.py
+++ b/beeline/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.4.2'
+VERSION = '2.4.3'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 setup(
     python_requires='>=2.7',
     name='honeycomb-beeline',
-    version='2.4.2',
+    version='2.4.3',
     description='Honeycomb library for easy instrumentation',
     url='https://github.com/honeycombio/beeline-python',
     author='Honeycomb.io',


### PR DESCRIPTION
Fixes https://github.com/honeycombio/beeline-python/issues/50

This was an oversight and I'm considering it a bugfix, hence the patch version change