### PR TITLE
[tracer] allow the tracer context manager to safely noop if not initi…

### DIFF
--- a/beeline/test_beeline.py
+++ b/beeline/test_beeline.py
@@ -165,3 +165,14 @@ class TestBeelineNotInitialized(unittest.TestCase):
         # this should not crash if the beeline isn't initialized
         # it should also accept arguments normally and return the function's value
         self.assertEqual(my_sum(1, 2), 3)
+
+    def test_tracer_context_manager(self):
+        ''' ensure the tracer context manager doesn't break if the beeline is not initialized '''
+        self.assertIsNone(beeline.get_beeline())
+        def my_sum(a, b):
+            with beeline.tracer(name="my_sum"):
+                return a + b
+
+        # this should not crash if the beeline isn't initialized
+        # it should also accept arguments normally and return the function's value
+        self.assertEqual(my_sum(1, 2), 3)

--- a/beeline/version.py
+++ b/beeline/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.4.3'
+VERSION = '2.4.4'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 setup(
     python_requires='>=2.7',
     name='honeycomb-beeline',
-    version='2.4.3',
+    version='2.4.4',
     description='Honeycomb library for easy instrumentation',
     url='https://github.com/honeycombio/beeline-python',
     author='Honeycomb.io',


### PR DESCRIPTION
…alized

As mentioned in https://github.com/honeycombio/beeline-python/issues/51, `tracer` raises
an exception if the beeline has not been initialized. This is the only part of the core API
that will crash an app if `init` has not been called. Add a check for initialization, and return a noop context manager if not initialized.