### PR TITLE
Fix tracing already decorated functions with beeline.traced

### DIFF
--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -1,4 +1,5 @@
 ''' module beeline '''
+import functools
 import os
 import socket
 
@@ -166,6 +167,7 @@ class Beeline(object):
 
     def traced(self, name, trace_id=None, parent_id=None):
         def wrapped(fn, *args, **kwargs):
+            @functools.wraps(fn)
             def inner(*args, **kwargs):
                 with self.tracer(name=name, trace_id=trace_id, parent_id=parent_id):
                     return fn(*args, **kwargs)
@@ -545,6 +547,7 @@ def traced(name, trace_id=None, parent_id=None):
     if not _beeline:
         # just pass through if not initialized
         def wrapped(fn, *args, **kwargs):
+            @functools.wraps(fn)
             def inner(*args, **kwargs):
                 return fn(*args, **kwargs)
             return inner


### PR DESCRIPTION
While working on https://github.com/honeycombio/beeline-python/issues/51, I've figured
that the current tracer does not really works with already decorated functions.
(The decorator I had changed the function in specific way, allowing fn.clear_cache being called.
This beeline.traced erased these changes).

I don't think there is anything contentious here since it's a good practice to wrap
decorators with this anyway.