### PR TITLE
[traced] defer evaluation of beeline initialization until function is…

### DIFF
--- a/beeline/test_beeline.py
+++ b/beeline/test_beeline.py
@@ -133,7 +133,7 @@ class TestBeeline(unittest.TestCase):
         self.assertEqual(val, 'asdf')
 
     def test_trace_wrapper(self):
-        ''' ensure that the trace wrapper decorarates a function and starts a trace '''
+        ''' ensure that the trace wrapper decorates a function and starts a trace '''
         _beeline = beeline.Beeline()
         with patch('beeline.get_beeline') as m_gbl:
             m_gbl.return_value = _beeline

--- a/beeline/version.py
+++ b/beeline/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.4.4'
+VERSION = '2.4.5'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 setup(
     python_requires='>=2.7',
     name='honeycomb-beeline',
-    version='2.4.4',
+    version='2.4.5',
     description='Honeycomb library for easy instrumentation',
     url='https://github.com/honeycombio/beeline-python',
     author='Honeycomb.io',


### PR DESCRIPTION
… called

While traced was setup to work correctly even if the beeline was uninitialized, the "is initialized" check was evaluated when the wrapped function definition was evaluated rather than when it was called. This meant that when you called `beeline.init` in your program affected whether or not traced functions were actually traced.

This does away with the initialization check when the function is wrapped, instead letting the context manager sort it out at execution time.