### PR TITLE
[bugfix] safer handling of utf-8 encoded exceptions

### DIFF
--- a/beeline/internal.py
+++ b/beeline/internal.py
@@ -16,3 +16,12 @@ def log(msg, *args, **kwargs):
     bl = beeline.get_beeline()
     if bl:
         bl.log(msg, *args, **kwargs)
+
+def stringify_exception(e):
+    try:
+        return str(e)
+    except UnicodeEncodeError:
+        try:
+            return u"{}".format(e)
+        except Exception:
+            return "unable to decode exception"

--- a/beeline/middleware/awslambda/__init__.py
+++ b/beeline/middleware/awslambda/__init__.py
@@ -50,12 +50,12 @@ def beeline_wrapper(handler):
             return handler(event, context)
 
         try:
-            # assume we're going to get bad values sometims in our headers
+            # assume we're going to get bad values sometimes in our headers
             trace_id, parent_id, trace_context = None, None, None
             try:
                 trace_id, parent_id, trace_context = _get_trace_data(event)
             except Exception as e:
-                beeline.internal.log('error attempting to extract trace context: %s', str(e))
+                beeline.internal.log('error attempting to extract trace context: %s', beeline.internal.stringify_exception(e))
                 pass
             with beeline.tracer(name=handler.__name__,
                     trace_id=trace_id, parent_id=parent_id):

--- a/beeline/middleware/django/__init__.py
+++ b/beeline/middleware/django/__init__.py
@@ -10,7 +10,7 @@ def _get_trace_context(request):
         try:
             return unmarshal_trace_context(trace_context)
         except Exception as e:
-            beeline.internal.log('error attempting to extract trace context: %s', str(e))
+            beeline.internal.log('error attempting to extract trace context: %s', beeline.internal.stringify_exception(e))
 
     return None, None, None
 
@@ -35,7 +35,7 @@ class HoneyDBWrapper(object):
                     "db.duration", db_call_diff.total_seconds() * 1000)
             except Exception as e:
                 beeline.add_context_field("db.error", str(type(e)))
-                beeline.add_context_field("db.error_detail", str(e))
+                beeline.add_context_field("db.error_detail", beeline.internal.stringify_exception(e))
                 raise
             else:
                 return result
@@ -93,7 +93,7 @@ class HoneyMiddlewareBase(object):
         return response
 
     def process_exception(self, request, exception):
-        beeline.add_context_field("request.error_detail", str(exception))
+        beeline.add_context_field("request.error_detail", beeline.internal.stringify_exception(exception))
 
 
 class HoneyMiddlewareHttp(HoneyMiddlewareBase):

--- a/beeline/middleware/flask/__init__.py
+++ b/beeline/middleware/flask/__init__.py
@@ -20,7 +20,7 @@ def _get_trace_context(environ):
         try:
             return unmarshal_trace_context(trace_context)
         except Exception as e:
-            beeline.internal.log('error attempting to extract trace context: %s', str(e))
+            beeline.internal.log('error attempting to extract trace context: %s', beeline.internal.stringify_exception(e))
 
     return None, None, None
 
@@ -36,7 +36,7 @@ class HoneyMiddleware(object):
 
     def _teardown_request(self, exception):
         if exception:
-            beeline.add_field('request.error_detail', str(exception))
+            beeline.add_field('request.error_detail', beeline.internal.stringify_exception(exception))
             beeline.add_field('request.error', str(type(exception)))
             beeline.internal.send_event()
 
@@ -142,7 +142,7 @@ class HoneyDBMiddleware(object):
         self.state.span = None
 
     def handle_error(self, context):
-        beeline.add_context_field("db.error", str(context.original_exception))
+        beeline.add_context_field("db.error", beeline.internal.stringify_exception(context.original_exception))
         if self.state.span:
             beeline.finish_span(self.state.span)
         self.state.span = None

--- a/beeline/patch/requests.py
+++ b/beeline/patch/requests.py
@@ -30,7 +30,7 @@ def request(_request, instance, args, kwargs):
         except Exception as e:
             beeline.add_context({
                 "request.error_type": str(type(e)),
-                "request.error": str(e),
+                "request.error": beeline.internal.stringify_exception(e),
             })
             raise
         finally:

--- a/beeline/patch/tornado.py
+++ b/beeline/patch/tornado.py
@@ -36,7 +36,7 @@ def log_exception(_log_exception, instance, args, kwargs):
                 "request.query": instance.request.query,
                 "request.host": instance.request.get('Host'),
                 "request.error": type(value).__name__,
-                "request.error_detail": str(value),
+                "request.error_detail": beeline.internal.stringify_exception(value),
             })
     except Exception:
         pass

--- a/beeline/test_internal.py
+++ b/beeline/test_internal.py
@@ -1,0 +1,12 @@
+import unittest
+
+from beeline.internal import stringify_exception
+
+class TestInternal(unittest.TestCase):
+    def test_stringify_exception(self):
+        '''ensure we don't crash handling utf-8 exceptions'''
+        e = Exception("foo")
+        self.assertEqual('foo', stringify_exception(e))
+
+        e = Exception(u"\u1024abcdef")
+        self.assertEqual(u'\u1024abcdef', stringify_exception(e))

--- a/beeline/trace.py
+++ b/beeline/trace.py
@@ -10,7 +10,7 @@ from functools import wraps
 
 from contextlib import contextmanager
 
-from beeline.internal import log
+from beeline.internal import log, stringify_exception
 
 MAX_INT32 = math.pow(2, 32) - 1
 
@@ -56,7 +56,7 @@ class SynchronousTracer(Tracer):
             if span:
                 span.add_context({
                     "app.exception_type": str(type(e)),
-                    "app.exception_string": str(e),
+                    "app.exception_string": stringify_exception(e),
                 })
             raise
         finally:

--- a/beeline/version.py
+++ b/beeline/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.4.5'
+VERSION = '2.4.6'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 setup(
     python_requires='>=2.7',
     name='honeycomb-beeline',
-    version='2.4.5',
+    version='2.4.6',
     description='Honeycomb library for easy instrumentation',
     url='https://github.com/honeycombio/beeline-python',
     author='Honeycomb.io',


### PR DESCRIPTION
We try to stringify exceptions that occur in a span, but we can't control the contents of the exceptions. In python2.7, an exception with a utf-8 string can break when we try to call str() on it. Adds a wrapper to make this safer.