### PR TITLE
[django] include view name in built-in django instrumentation

### DIFF
--- a/beeline/middleware/django/__init__.py
+++ b/beeline/middleware/django/__init__.py
@@ -95,6 +95,11 @@ class HoneyMiddlewareBase(object):
     def process_exception(self, request, exception):
         beeline.add_context_field("request.error_detail", beeline.internal.stringify_exception(exception))
 
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        try:
+            beeline.add_context_field("django.view_func", view_func.__name__)
+        except AttributeError:
+            pass
 
 class HoneyMiddlewareHttp(HoneyMiddlewareBase):
     pass

--- a/beeline/version.py
+++ b/beeline/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.4.7'
+VERSION = '2.5.0'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 setup(
     python_requires='>=2.7',
     name='honeycomb-beeline',
-    version='2.4.7',
+    version='2.5.0',
     description='Honeycomb library for easy instrumentation',
     url='https://github.com/honeycombio/beeline-python',
     author='Honeycomb.io',


### PR DESCRIPTION
Django middleware provides an optional `process_view` hook (see here: https://docs.djangoproject.com/en/2.1/topics/http/middleware/#process-view) - we can use this to extract the view name that is being called and add it as another field to the event that represents the request. It also provides `view_args` and `view_kwargs` but I'd rather not log these by default as they may contain sensitive data.