### PR TITLE
[middleware] support dict parameters type in flask middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# beeline-python changelog
+
+## 2.5.1 2019-05-13
+
+Fixes
+
+- Support parameters of type `dict` in the flask-sqlachemy middleware. Addresses [#62](https://github.com/honeycombio/beeline-python/issues/62).

--- a/beeline/middleware/flask/__init__.py
+++ b/beeline/middleware/flask/__init__.py
@@ -112,10 +112,20 @@ class HoneyDBMiddleware(object):
             return
 
         params = []
-        for param in parameters:
-            if type(param) == datetime.datetime:
-                param = param.isoformat()
-            params.append(param)
+
+        # the type of parameters passed in varies depending on DB - handle list, dict, and tuple
+        if type(parameters) == tuple or type(parameters) == list:
+            for param in parameters:
+                if type(param) == datetime.datetime:
+                    param = param.isoformat()
+                params.append(param)
+        elif type(parameters) == dict:
+            for k,v in parameters.items():
+                param = "%s=" % k
+                if type(v) == datetime.datetime:
+                     v = v.isoformat()
+                param += "%s" % v
+                params.append(param)
 
         self.state.span = beeline.start_span(context={
             "name": "flask_db_query",

--- a/beeline/version.py
+++ b/beeline/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.5.0'
+VERSION = '2.5.1'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 setup(
     python_requires='>=2.7',
     name='honeycomb-beeline',
-    version='2.5.0',
+    version='2.5.1',
     description='Honeycomb library for easy instrumentation',
     url='https://github.com/honeycombio/beeline-python',
     author='Honeycomb.io',


### PR DESCRIPTION
Fixes https://github.com/honeycombio/beeline-python/issues/62.

Bumps version to 2.5.1