### PR TITLE
[tracing] add interop test, fix deterministic sampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # beeline-python changelog
 
+## 2.6.1 2019-07-02
+
+Fixes
+
+- Python Beeline now uses the same method to compute deterministic sampling decisions as other beelines (Go, NodeJS, Ruby). Prior to the fix, Beeline-generated traces spanning multiple services implemented in Python and other languages would have sometimes arrived incomplete due to inconsistent sampling behavior.
+
 ## 2.6.0 2019-06-05 - Update recommended
 
 Features

--- a/beeline/test_trace.py
+++ b/beeline/test_trace.py
@@ -13,11 +13,73 @@ from beeline.trace import (
 class TestTraceSampling(unittest.TestCase):
     def test_deterministic(self):
         ''' test a specific id that should always work with the given sample rate '''
-        trace_id = '8bd68312-a3ce-4bf8-a2df-896cef4289e5'
+        trace_id = 'b8d674f1-04ed-4ea8-b16d-b4dbbe87c78e'
         n = 0
         while n < 1000:
             self.assertTrue(_should_sample(trace_id, 1000))
             n += 1
+
+    def test_deterministic_interop(self):
+        '''test a specific set of ids that should always have the given result (at sample rate 2)
+        Ensures interoperability with other beelines'''
+        ids = [
+            "4YeYygWjTZ41zOBKUoYUaSVxPGm78rdU",
+            "iow4KAFBl9u6lF4EYIcsFz60rXGvu7ph",
+            "EgQMHtruEfqaqQqRs5nwaDXsegFGmB5n",
+            "UnVVepVdyGIiwkHwofyva349tVu8QSDn",
+            "rWuxi2uZmBEprBBpxLLFcKtXHA8bQkvJ",
+            "8PV5LN1IGm5T0ZVIaakb218NvTEABNZz",
+            "EMSmscnxwfrkKd1s3hOJ9bL4zqT1uud5",
+            "YiLx0WGJrQAge2cVoAcCscDDVidbH4uE",
+            "IjD0JHdQdDTwKusrbuiRO4NlFzbPotvg",
+            "ADwiQogJGOS4X8dfIcidcfdT9fY2WpHC",
+            "DyGaS7rfQsMX0E6TD9yORqx7kJgUYvNR",
+            "MjOCkn11liCYZspTAhdULMEfWJGMHvpK",
+            "wtGa41YcFMR5CBNr79lTfRAFi6Vhr6UF",
+            "3AsMjnpTBawWv2AAPDxLjdxx4QYl9XXb",
+            "sa2uMVNPiZLK52zzxlakCUXLaRNXddBz",
+            "NYH9lkdbvXsiUFKwJtjSkQ1RzpHwWloK",
+            "8AwzQeY5cudY8YUhwxm3UEP7Oos61RTY",
+            "ADKWL3p5gloRYO3ptarTCbWUHo5JZi3j",
+            "UAnMARj5x7hkh9kwBiNRfs5aYDsbHKpw",
+            "Aes1rgTLMNnlCkb9s6bH7iT5CbZTdxUw",
+            "eh1LYTOfgISrZ54B7JbldEpvqVur57tv",
+            "u5A1wEYax1kD9HBeIjwyNAoubDreCsZ6",
+            "mv70SFwpAOHRZt4dmuw5n2lAsM1lOrcx",
+            "i4nIu0VZMuh5hLrUm9w2kqNxcfYY7Y3a",
+            "UqfewK2qFZqfJ619RKkRiZeYtO21ngX1",
+        ]
+        expected = [
+            False,
+            True,
+            True,
+            True,
+            True,
+            False,
+            True,
+            True,
+            False,
+            False,
+            True,
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+            True,
+            True,
+            False,
+            False,
+            True,
+            True,
+            False,
+        ]
+
+        for i in range(len(ids)):
+            self.assertEqual(_should_sample(ids[i], 2), expected[i])
+
 
     def test_probability(self):
         ''' test that _should_sample approximates 1 in N sampling for random IDs '''
@@ -270,7 +332,7 @@ class TestSynchronousTracer(unittest.TestCase):
             m_sample_fn.return_value = True
             tracer._run_hooks_and_send(m_span)
 
-        # no hooks - trace's _should_sample is rigged to always return true, so we
+        # no hooks - trace's _should_sample is rigged to always return True, so we
         # always call send_presampled
         # send should never be called because at a minimum we always do deterministic
         # sampling

--- a/beeline/trace.py
+++ b/beeline/trace.py
@@ -267,7 +267,7 @@ def _should_sample(trace_id, sample_rate):
     sha1 = hashlib.sha1()
     sha1.update(trace_id.encode('utf-8'))
     # convert last 4 digits to int
-    value, = struct.unpack('<I', sha1.digest()[-4:])
+    value, = struct.unpack('>I', sha1.digest()[:4])
     if value < sample_upper_bound:
         return True
     return False

--- a/beeline/version.py
+++ b/beeline/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.6.0'
+VERSION = '2.6.1'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 setup(
     python_requires='>=2.7',
     name='honeycomb-beeline',
-    version='2.6.0',
+    version='2.6.1',
     description='Honeycomb library for easy instrumentation',
     url='https://github.com/honeycombio/beeline-python',
     author='Honeycomb.io',


### PR DESCRIPTION
A couple of differences in the deterministic sampler implementation meant that the python beeline would produce different sampling decisions than the go, node, ruby, etc beelines. After adding a test in https://github.com/honeycombio/beeline-go/pull/68, also implemented the same test here and fixed the issues that it detected.