### PR TITLE
Lambda instrumentation graceful fail

### DIFF
--- a/beeline/middleware/awslambda/__init__.py
+++ b/beeline/middleware/awslambda/__init__.py
@@ -60,9 +60,9 @@ def beeline_wrapper(handler):
             with beeline.tracer(name=handler.__name__,
                     trace_id=trace_id, parent_id=parent_id):
                 beeline.add_context({
-                    "app.function_name": context.function_name or "",
-                    "app.function_version": context.function_version or "",
-                    "app.request_id": context.aws_request_id or "",
+                    "app.function_name": getattr(context, 'function_name', ""),
+                    "app.function_version": getattr(context, 'function_version', ""),
+                    "app.request_id": getattr(context, 'aws_request_id', ""),
                     "app.event": event,
                     "meta.cold_start": COLD_START,
                 })

--- a/beeline/middleware/awslambda/__init__.py
+++ b/beeline/middleware/awslambda/__init__.py
@@ -60,9 +60,9 @@ def beeline_wrapper(handler):
             with beeline.tracer(name=handler.__name__,
                     trace_id=trace_id, parent_id=parent_id):
                 beeline.add_context({
-                    "app.function_name": context.function_name,
-                    "app.function_version": context.function_version,
-                    "app.request_id": context.aws_request_id,
+                    "app.function_name": context.function_name or "",
+                    "app.function_version": context.function_version or "",
+                    "app.request_id": context.aws_request_id or "",
                     "app.event": event,
                     "meta.cold_start": COLD_START,
                 })


### PR DESCRIPTION
Hi,

When doing unit tests on Honeycomb-instrumented Lambdas, the tests would fail to run due to the `context` object not being populated.

This PR adds a blank default in case the attributes cannot be used.