### PR TITLE
[middleware] Don't try to access self.state.span in handle_error of Flask DB middleware if there is no current_app

### DIFF
--- a/beeline/middleware/flask/__init__.py
+++ b/beeline/middleware/flask/__init__.py
@@ -156,6 +156,9 @@ class HoneyDBMiddleware(object):
         self.state.span = None
 
     def handle_error(self, context):
+        if not current_app:
+            return
+
         beeline.add_context_field("db.error", beeline.internal.stringify_exception(context.original_exception))
         if self.state.span:
             beeline.finish_span(self.state.span)


### PR DESCRIPTION
Both `before_cursor_execute` and `after_cursor_execute` exit early 
if there is no `current_app`, but `handle_error` tries to finish
the span even if there is no `current_app`. This caused an
`AttributeError` when I was using beeline-python in the context of a
multi-threaded application, since when we used `HoneyDBMiddleware` off
of the thread it had been initialized on, `self.state.span` was never
set. We could probably also fix this by using `getattr` on `self.state`
before accessing `span`, but this seems more consistent with how the
other methods operate.