### PR TITLE
Add support for tracing asynchronous code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,27 @@
 version: 2.1
 
 commands:
-  runtests:
+  setup:
     steps:
       - checkout
       - run:
           command: |
             sudo pip install pyflakes==1.5.0 pylint setuptools-lint coverage
             sudo pip install --upgrade setuptools
+  runtests-py2:
+    steps:
+      - run:
+          command: |
+            python setup.py lint --lint-ignore aiotrace.py,test_async.py --lint-rcfile pylint.rc
+            coverage run ./setup.py test
+            coverage report --include="beeline/*"
+            coverage html --include="beeline/*"
+      - store_artifacts:
+          path: htmlcov
+  runtests-py3:
+    steps:
+      - run:
+          command: |
             pyflakes beeline
             python setup.py lint --lint-rcfile pylint.rc
             coverage run ./setup.py test
@@ -58,19 +72,23 @@ jobs:
   test_python2-7:
     executor: python2-7
     steps:
-      - runtests
+      - setup
+      - runtests-py2
   test_python3-5:
     executor: python3-5
     steps:
-      - runtests
+      - setup
+      - runtests-py3
   test_python3-6:
     executor: python3-6
     steps:
-      - runtests
+      - setup
+      - runtests-py3
   test_python3-7:
     executor: python3-7
     steps:
-      - runtests
+      - setup
+      - runtests-py3
   publish:
     executor: python3-7
     steps:

--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -26,7 +26,8 @@ try:
     import contextvars
     assert contextvars
 
-    from beeline.aiotrace import AsyncioTracer, traced_impl
+    from beeline.aiotrace import AsyncioTracer, traced_impl, untraced
+    assert untraced
 
     def in_async_code():
         """Return wether we are running inside an asynchronous task.

--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -45,20 +45,10 @@ try:
 except ImportError:
     # Use these non-async versions if we don't have asyncio or
     # contextvars.
+    from beeline.trace import traced_impl
+
     def in_async_code():
         return False
-
-    def traced_impl(tracer_fn, name, trace_id, parent_id):
-        """Implementation of the traced decorator without async support."""
-        def wrapped(fn):
-            @functools.wraps(fn)
-            def inner(*args, **kwargs):
-                with tracer_fn(name=name, trace_id=trace_id, parent_id=parent_id):
-                    return fn(*args, **kwargs)
-
-            return inner
-
-        return wrapped
 
 class Beeline(object):
     def __init__(self,

--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -207,7 +207,7 @@ class Beeline(object):
         return traced_impl(tracer_fn=self.tracer, name=name, trace_id=trace_id, parent_id=parent_id)
 
     def traced_thread(self, fn):
-        trace_copy = self.tracer_impl._state.trace.copy()
+        trace_copy = self.tracer_impl._trace.copy()
 
         @functools.wraps(fn)
         def wrapped(*args, **kwargs):
@@ -660,7 +660,7 @@ def traced_thread(fn):
             return fn(*args, **kwargs)
         return noop
 
-    trace_copy = bl.tracer_impl._state.trace.copy()
+    trace_copy = bl.tracer_impl._trace.copy()
 
     @functools.wraps(fn)
     def wrapped(*args, **kwargs):

--- a/beeline/aiotrace.py
+++ b/beeline/aiotrace.py
@@ -1,0 +1,59 @@
+"""Asynchronous tracer implementation.
+
+This requires Python 3.7, because it uses the contextvars module.
+
+"""
+import asyncio
+import contextvars  # pylint: disable=import-error
+
+from beeline.trace import Tracer
+
+current_trace_var = contextvars.ContextVar("current_trace")
+
+
+def create_task_factory(parent_factory):
+    """Create a task factory that makes a copy of the current trace.
+
+    New tasks have their own context variables, but the current_trace
+    context variable still refers to the same Trace object as the one
+    in the parent task. This task factory replaces the Trace object
+    with a copy of itself.
+
+    """
+    def task_factory_impl(loop, coro):
+        async def wrapper():
+            current_trace = current_trace_var.get(None)
+            if current_trace is not None:
+                current_trace_var.set(current_trace.copy())
+            return await coro
+
+        if parent_factory is None:
+            task = asyncio.tasks.Task(wrapper(), loop=loop)
+        else:
+            task = parent_factory(wrapper())
+
+        return task
+
+    task_factory_impl.__trace_task_factory__ = True
+    return task_factory_impl
+
+
+class AsyncioTracer(Tracer):
+    def __init__(self, client):
+        """Initialize, and ensure that our task factory is set up."""
+        super().__init__(client)
+
+        loop = asyncio.get_running_loop()  # pylint: disable=no-member
+
+        task_factory = loop.get_task_factory()
+        if task_factory is None or not task_factory.__trace_task_factory__:
+            new_task_factory = create_task_factory(task_factory)
+            loop.set_task_factory(new_task_factory)
+
+    @property
+    def _trace(self):
+        return current_trace_var.get(None)
+
+    @_trace.setter
+    def _trace(self, new_trace):
+        current_trace_var.set(new_trace)

--- a/beeline/test_async.py
+++ b/beeline/test_async.py
@@ -1,0 +1,205 @@
+import asyncio
+import datetime
+import unittest
+
+import beeline
+import beeline.aiotrace
+import beeline.trace
+
+
+def async_test(fn):
+    """Decorator for making async methods usable as tests.
+
+    This decorator also runs the async_setup method before each test,
+    if it exists.
+
+    """
+    def wrapper(self, *args, **kwargs):
+        async def sequence():
+            if hasattr(self, "async_setup"):
+                await self.async_setup()
+            return await fn(self, *args, **kwargs)
+
+        return asyncio.run(sequence(*args, **kwargs))  # pylint: disable=no-member
+
+    return wrapper
+
+
+def span_data(span):
+    """Utility for converting Span objects to dicts."""
+    name = span.event.fields().get("name")
+    start = span.event.start_time
+    duration = datetime.timedelta(
+        milliseconds=span.event.fields()["duration_ms"]
+    )
+    end = start + duration
+    return {
+        "name": name,
+        "start": start,
+        "end": end,
+        "trace_id": span.trace_id,
+        "span": span,
+    }
+
+
+class TestTracerImplChoice(unittest.TestCase):
+    def test_synchronous_tracer_should_be_used_by_default(self):
+        """Verify that the SynchronousTracer implementation is chosen when a
+        Beeline object is initialised outside of an asyncio loop.
+
+        """
+        _beeline = beeline.Beeline()
+        self.assertIsInstance(
+            _beeline.tracer_impl, beeline.trace.SynchronousTracer
+        )
+
+    @async_test
+    async def test_asyncio_tracer_should_be_used_in_async_code(self):
+        """Verify that the AsyncioTracer implementation is chosen when a
+        Beeline object is initialised while running inside an asyncio
+        loop.
+
+        """
+        _beeline = beeline.Beeline()
+        self.assertIsInstance(
+            _beeline.tracer_impl, beeline.aiotrace.AsyncioTracer
+        )
+
+
+class TestAsynchronousTracer(unittest.TestCase):
+    async def async_setup(self):
+        self.finished_spans = []
+
+        def add_span(span):
+            self.finished_spans.append(span_data(span))
+
+        self.beeline = beeline.Beeline()
+        self.tracer = self.beeline.tracer_impl
+        self.tracer._run_hooks_and_send = add_span
+
+    @async_test
+    async def test_tracing_in_new_tasks_should_work(self):
+        """Test that basic AsyncioTracer functionality is present."""
+        trace = self.tracer.start_trace()
+        self.tracer.finish_trace(trace)
+
+        self.assertEqual(len(self.finished_spans), 1)
+
+    @async_test
+    async def test_traces_started_in_different_tasks_should_be_independent(self):
+        """Fork off two tasks, each calling start_trace.
+
+        The traces run simultaneously. This is expected to produce two
+        independent traces without raising any exceptions.
+
+        """
+        async def task0():
+            trace0 = self.tracer.start_trace(context={"name": "task0"})
+            await asyncio.sleep(0.2)
+            self.tracer.finish_trace(trace0)
+
+        async def task1():
+            await asyncio.sleep(0.1)
+            trace1 = self.tracer.start_trace(context={"name": "task1"})
+            await asyncio.sleep(0.2)
+            self.tracer.finish_trace(trace1)
+
+        await asyncio.gather(task0(), task1())
+
+        self.assertEqual(len(self.finished_spans), 2)
+        task0_span, task1_span = self.finished_spans  # pylint: disable=unbalanced-tuple-unpacking
+
+        # Check that the spans finished in the expected order.
+        self.assertEqual(task0_span["name"], "task0")
+        self.assertEqual(task1_span["name"], "task1")
+        self.assertLess(task0_span["end"], task1_span["end"])
+
+        # Check that the task0 started before task1
+        self.assertLess(task0_span["start"], task1_span["start"])
+
+        # Check that the task1 span started during the task0 span
+        self.assertLess(task1_span["start"], task0_span["end"])
+
+        # Check that the task spans are both root spans
+        self.assertTrue(task0_span["span"].is_root())
+        self.assertTrue(task1_span["span"].is_root())
+
+    @async_test
+    async def test_new_tasks_should_trace_in_parallel(self):
+        """Fork off two tasks after starting a trace.
+
+        Both tasks record a span, overlapping with each other. Both
+        spans are expected to have the root span as their parent.
+
+        """
+
+        trace = self.tracer.start_trace(context={"name": "root"})
+
+        async def task0():
+            span0 = self.tracer.start_span(context={"name": "task0"})
+            await asyncio.sleep(0.2)
+            self.tracer.finish_span(span0)
+
+        async def task1():
+            await asyncio.sleep(0.1)
+            span1 = self.tracer.start_span(context={"name": "task1"})
+            await asyncio.sleep(0.2)
+            self.tracer.finish_span(span1)
+
+        await asyncio.gather(task0(), task1())
+
+        self.tracer.finish_trace(trace)
+
+        self.assertEqual(len(self.finished_spans), 3)
+        task0_span, task1_span, root_span = self.finished_spans  # pylint: disable=unbalanced-tuple-unpacking
+
+        # Check that the spans finished in the expected order, with
+        # the root span last.
+        self.assertEqual(task0_span["name"], "task0")
+        self.assertEqual(task1_span["name"], "task1")
+        self.assertLess(task0_span["end"], task1_span["end"])
+        self.assertEqual(root_span["name"], "root")
+        self.assertLessEqual(task1_span["end"], root_span["end"])
+
+        # Check that the root span was started before the others.
+        self.assertLess(root_span["start"], task0_span["start"])
+        self.assertLess(root_span["start"], task1_span["start"])
+
+        # Check that the task0 started before task1
+        self.assertLess(task0_span["start"], task1_span["start"])
+
+        # Check that the task1 span started during the task0 span
+        self.assertLess(task1_span["start"], task0_span["end"])
+
+        # Check that the task spans are both children of the root span
+        self.assertEqual(root_span["span"].id, task0_span["span"].parent_id)
+        self.assertEqual(root_span["span"].id, task1_span["span"].parent_id)
+
+    @async_test
+    async def test_traceless_spans_in_other_tasks_should_be_ignored(self):
+        """Start a span without first starting a trace in the same task.
+
+        This span is started while there is a trace started in another
+        task. This span should be independent from that trace, and is
+        expected to be ignored.
+
+        """
+        async def task0():
+            await asyncio.sleep(0.2)
+            trace = self.tracer.start_trace(context={"name": "task0"})
+            await asyncio.sleep(0.2)
+            self.tracer.finish_trace(trace)
+
+        async def task1():
+            await asyncio.sleep(0.1)
+            span = self.tracer.start_span(context={"name": "task1"})
+            await asyncio.sleep(0.2)
+            self.tracer.finish_span(span)
+
+        await asyncio.gather(task0(), task1())
+
+        self.assertEqual(len(self.finished_spans), 1)
+        task0_span = self.finished_spans[0]
+
+        # Check that only the trace produced a span.
+        self.assertEqual(task0_span["name"], "task0")

--- a/beeline/test_async.py
+++ b/beeline/test_async.py
@@ -176,6 +176,59 @@ class TestAsynchronousTracer(unittest.TestCase):
         self.assertEqual(root_span["span"].id, task1_span["span"].parent_id)
 
     @async_test
+    async def test_traced_decorators(self):
+        """Fork off two tasks after starting a trace.
+
+        This is the same as test_new_tasks_should_trace_in_parallel,
+        except it uses the traced decorator to record the sub-spans.
+
+        """
+        trace = self.tracer.start_trace(context={"name": "root"})
+
+        @self.beeline.traced("task0")
+        async def task0():
+            await asyncio.sleep(0.2)
+
+        async def task1():
+            await asyncio.sleep(0.1)
+
+            @self.beeline.traced("task1")
+            async def decorated_fn():
+                await asyncio.sleep(0.2)
+
+            await decorated_fn()
+
+        await asyncio.gather(task0(), task1())
+
+        self.tracer.finish_trace(trace)
+
+        self.assertEqual(len(self.finished_spans), 3)
+
+        task0_span, task1_span, root_span = self.finished_spans  # pylint: disable=unbalanced-tuple-unpacking
+
+        # Check that the spans finished in the expected order, with
+        # the root span last.
+        self.assertEqual(task0_span["name"], "task0")
+        self.assertEqual(task1_span["name"], "task1")
+        self.assertLess(task0_span["end"], task1_span["end"])
+        self.assertEqual(root_span["name"], "root")
+        self.assertLessEqual(task1_span["end"], root_span["end"])
+
+        # Check that the root span was started before the others.
+        self.assertLess(root_span["start"], task0_span["start"])
+        self.assertLess(root_span["start"], task1_span["start"])
+
+        # Check that the task0 started before task1
+        self.assertLess(task0_span["start"], task1_span["start"])
+
+        # Check that the task1 span started during the task0 span
+        self.assertLess(task1_span["start"], task0_span["end"])
+
+        # Check that the task spans are both children of the root span
+        self.assertEqual(root_span["span"].id, task0_span["span"].parent_id)
+        self.assertEqual(root_span["span"].id, task1_span["span"].parent_id)
+
+    @async_test
     async def test_traceless_spans_in_other_tasks_should_be_ignored(self):
         """Start a span without first starting a trace in the same task.
 

--- a/beeline/test_beeline.py
+++ b/beeline/test_beeline.py
@@ -175,32 +175,32 @@ class TestBeeline(unittest.TestCase):
             _beeline.tracer_impl._run_hooks_and_send = Mock()
 
             _beeline.tracer_impl.start_trace(trace_id="asdf")
-            self.assertEqual(_beeline.tracer_impl._state.trace_id, "asdf")
+            self.assertEqual(_beeline.tracer_impl._trace.id, "asdf")
 
             def thread_func():
                 # confirm no trace state in new thread
-                self.assertFalse(hasattr(_beeline.tracer_impl._state, 'trace_id'))
+                self.assertIsNone(_beeline.tracer_impl._trace)
 
             self.raising_run_in_thread(target=thread_func)
 
             @beeline.traced_thread
             def traced_thread_func():
-                self.assertEqual(_beeline.tracer_impl._state.trace_id, "asdf")
+                self.assertEqual(_beeline.tracer_impl._trace.id, "asdf")
 
                 with _beeline.tracer(name="foo") as span:
                     self.assertEqual(span.trace_id, "asdf")
-                    self.assertEqual(span.parent_id, _beeline.tracer_impl._state.stack[0].id)
+                    self.assertEqual(span.parent_id, _beeline.tracer_impl._trace.stack[0].id)
 
             self.raising_run_in_thread(target=traced_thread_func)
 
             # test use of beeline client
             @_beeline.traced_thread
             def traced_thread_func_2():
-                self.assertEqual(_beeline.tracer_impl._state.trace_id, "asdf")
+                self.assertEqual(_beeline.tracer_impl._trace.id, "asdf")
 
                 with _beeline.tracer(name="foo2") as span:
                     self.assertEqual(span.trace_id, "asdf")
-                    self.assertEqual(span.parent_id, _beeline.tracer_impl._state.stack[0].id)
+                    self.assertEqual(span.parent_id, _beeline.tracer_impl._trace.stack[0].id)
 
             self.raising_run_in_thread(target=traced_thread_func_2)
 

--- a/beeline/test_suite.py
+++ b/beeline/test_suite.py
@@ -1,0 +1,20 @@
+from unittest import defaultTestLoader
+
+try:
+    # The async functionality uses the contextvars module, added in
+    # Python 3.7
+    import contextvars
+except ImportError:
+    contextvars = None
+
+
+def get_test_suite():
+    """Return the set of tests suitable for the current Python version"""
+    test_suite = defaultTestLoader.loadTestsFromNames(
+        ("beeline.test_beeline", "beeline.test_internal", "beeline.test_trace")
+    )
+    if contextvars:
+        async_suite = defaultTestLoader.loadTestsFromName("beeline.test_async")
+        test_suite.addTest(async_suite)
+
+    return test_suite

--- a/beeline/trace.py
+++ b/beeline/trace.py
@@ -31,23 +31,11 @@ class Trace(object):
         return result
 
 class Tracer(object):
-    pass
-
-class SynchronousTracer(Tracer):
     def __init__(self, client):
         self._client = client
-        self._state = threading.local()
 
         self.presend_hook = None
         self.sampler_hook = None
-
-    @property
-    def _trace(self):
-        return getattr(self._state, 'trace', None)
-
-    @_trace.setter
-    def _trace(self, new_trace):
-        self._state.trace = new_trace
 
     @contextmanager
     def __call__(self, name, trace_id=None, parent_id=None):
@@ -274,6 +262,19 @@ class SynchronousTracer(Tracer):
         elif _should_sample(span.trace_id, span.event.sample_rate):
             # if our sampler hook wasn't used, use deterministic sampling
             span.event.send_presampled()
+
+class SynchronousTracer(Tracer):
+    def __init__(self, client):
+        super(SynchronousTracer, self).__init__(client)
+        self._state = threading.local()
+
+    @property
+    def _trace(self):
+        return getattr(self._state, 'trace', None)
+
+    @_trace.setter
+    def _trace(self, new_trace):
+        self._state.trace = new_trace
 
 class Span(object):
     ''' Span represents an active span. Should not be initialized directly, but

--- a/beeline/trace.py
+++ b/beeline/trace.py
@@ -1,6 +1,7 @@
 import base64
 import copy
 import datetime
+import functools
 import hashlib
 import json
 import math
@@ -346,3 +347,15 @@ def unmarshal_trace_context(trace_context):
                 context = json.loads(base64.b64decode(v.encode()).decode())
 
     return trace_id, parent_id, context
+
+def traced_impl(tracer_fn, name, trace_id, parent_id):
+    """Implementation of the traced decorator without async support."""
+    def wrapped(fn):
+        @functools.wraps(fn)
+        def inner(*args, **kwargs):
+            with tracer_fn(name=name, trace_id=trace_id, parent_id=parent_id):
+                return fn(*args, **kwargs)
+
+        return inner
+
+    return wrapped

--- a/beeline/trace.py
+++ b/beeline/trace.py
@@ -1,4 +1,5 @@
 import base64
+import copy
 import datetime
 import hashlib
 import json
@@ -7,7 +8,6 @@ import struct
 import threading
 import uuid
 from collections import defaultdict
-from functools import wraps
 
 from contextlib import contextmanager
 
@@ -15,18 +15,20 @@ from beeline.internal import log, stringify_exception
 
 MAX_INT32 = math.pow(2, 32) - 1
 
-def init_state(f):
-    ''' Ensure thread local state is initialized in each thread '''
-    @wraps(f)
-    def d(self, *args, **kwargs):
-        if not hasattr(self._state, 'trace_id'):
-            self._state.trace_id = None
-            self._state.stack = []
-            self._state.trace_fields = {}
-            self._state.trace_rollup_fields = defaultdict(float)
+class Trace(object):
+    '''Object encapsulating all state of an ongoing trace.'''
+    def __init__(self, trace_id):
+        self.id = trace_id
+        self.stack = []
+        self.fields = {}
+        self.rollup_fields = defaultdict(float)
 
-        return f(self, *args, **kwargs)
-    return d
+    def copy(self):
+        '''Copy the trace state for use in another thread or context.'''
+        result = Trace(self.id)
+        result.stack = copy.copy(self.stack)
+        result.fields = copy.copy(self.fields)
+        return result
 
 class Tracer(object):
     pass
@@ -38,6 +40,14 @@ class SynchronousTracer(Tracer):
 
         self.presend_hook = None
         self.sampler_hook = None
+
+    @property
+    def _trace(self):
+        return getattr(self._state, 'trace', None)
+
+    @_trace.setter
+    def _trace(self, new_trace):
+        self._state.trace = new_trace
 
     @contextmanager
     def __call__(self, name, trace_id=None, parent_id=None):
@@ -74,27 +84,20 @@ class SynchronousTracer(Tracer):
             else:
                 log('tracer context manager span for %s was unexpectedly None', name)
 
-    @init_state
     def start_trace(self, context=None, trace_id=None, parent_span_id=None):
         if trace_id:
-            if self._state.trace_id:
+            if self._trace:
                 log('warning: start_trace got explicit trace_id but we are already in a trace. '
                     'starting new trace with id = %s', trace_id)
-            self._state.trace_id = trace_id
+            self._trace = Trace(trace_id)
         else:
-            self._state.trace_id = str(uuid.uuid4())
-
-        # reset our stack and context on new traces
-        self._state.stack = []
-        self._state.trace_fields = {}
-        self._state.trace_rollup_fields = defaultdict(float)
+            self._trace = Trace(str(uuid.uuid4()))
 
         # start the root span
         return self.start_span(context=context, parent_id=parent_span_id)
 
-    @init_state
     def start_span(self, context=None, parent_id=None):
-        if not self._state.trace_id:
+        if not self._trace:
             log('start_span called but no trace is active')
             return None
 
@@ -102,24 +105,23 @@ class SynchronousTracer(Tracer):
         if parent_id:
             parent_span_id = parent_id
         else:
-            parent_span_id = self._state.stack[-1].id if self._state.stack else None
-        ev = self._client.new_event(data=self._state.trace_fields)
+            parent_span_id = self._trace.stack[-1].id if self._trace.stack else None
+        ev = self._client.new_event(data=self._trace.fields)
         if context:
             ev.add(data=context)
 
         ev.add(data={
-            'trace.trace_id': self._state.trace_id,
+            'trace.trace_id': self._trace.id,
             'trace.parent_id': parent_span_id,
             'trace.span_id': span_id,
         })
-        is_root = len(self._state.stack) == 0
-        span = Span(trace_id=self._state.trace_id, parent_id=parent_span_id,
+        is_root = len(self._trace.stack) == 0
+        span = Span(trace_id=self._trace.id, parent_id=parent_span_id,
                     id=span_id, event=ev, is_root=is_root)
-        self._state.stack.append(span)
+        self._trace.stack.append(span)
 
         return span
 
-    @init_state
     def finish_span(self, span):
         # avoid exception if called with None
         if span is None:
@@ -128,19 +130,20 @@ class SynchronousTracer(Tracer):
         # send the span's event. Even if the stack is in an unhealthy state,
         # it's probably better to send event data than not
         if span.event:
-            # add the trace's rollup fields to the root span
-            if span.is_root():
-                for k, v in self._state.trace_rollup_fields.items():
+            if self._trace:
+                # add the trace's rollup fields to the root span
+                if span.is_root():
+                    for k, v in self._trace.rollup_fields.items():
+                        span.event.add_field(k, v)
+
+                for k, v in span.rollup_fields.items():
                     span.event.add_field(k, v)
 
-            for k, v in span.rollup_fields.items():
-                span.event.add_field(k, v)
-
-            # propagate trace fields that may have been added in later spans
-            for k, v in self._state.trace_fields.items():
-                # don't overwrite existing values because they may be different
-                if k not in span.event.fields():
-                    span.event.add_field(k, v)
+                # propagate trace fields that may have been added in later spans
+                for k, v in self._trace.fields.items():
+                    # don't overwrite existing values because they may be different
+                    if k not in span.event.fields():
+                        span.event.add_field(k, v)
 
             duration = datetime.datetime.now() - span.event.start_time
             duration_ms = duration.total_seconds() * 1000.0
@@ -150,34 +153,38 @@ class SynchronousTracer(Tracer):
         else:
             log('warning: span has no event, was it initialized correctly?')
 
-        if span.trace_id != self._state.trace_id:
-            log('warning: finished span called for span in inactive trace. '
-                'current trace_id = %s, span trace_id = %s', self._state.trace_id, span.trace_id)
+        if not self._trace:
+            log('warning: span finished without an active trace')
             return
 
-        if not self._state.stack:
+        if span.trace_id != self._trace.id:
+            log('warning: finished span called for span in inactive trace. '
+                'current trace_id = %s, span trace_id = %s', self._trace.id, span.trace_id)
+            return
+
+        if not self._trace.stack:
             log('warning: finish span called but stack is empty')
             return
 
-        if self._state.stack[-1].id != span.id:
+        if self._trace.stack[-1].id != span.id:
             log('warning: finished span is not the currently active span')
             return
 
-        self._state.stack.pop()
+        self._trace.stack.pop()
 
-    @init_state
     def finish_trace(self, span):
         self.finish_span(span)
-        self._state.trace_id = None
+        self._trace = None
 
-    @init_state
     def get_active_trace_id(self):
-        return self._state.trace_id
+        if self._trace:
+            return self._trace.id
+        return None
 
-    @init_state
     def get_active_span(self):
-        if self._state.stack:
-            return self._state.stack[-1]
+        if self._trace and self._trace.stack:
+            return self._trace.stack[-1]
+        return None
 
     def add_context_field(self, name, value):
         span = self.get_active_span()
@@ -194,7 +201,6 @@ class SynchronousTracer(Tracer):
         if span:
             span.remove_context_field(name=name)
 
-    @init_state
     def add_rollup_field(self, name, value):
         value = float(value)
 
@@ -202,33 +208,40 @@ class SynchronousTracer(Tracer):
         if span:
             span.rollup_fields[name] += value
 
-        self._state.trace_rollup_fields["rollup.%s" % name] += value
+        if not self._trace:
+            log('warning: adding rollup field without an active trace')
+            return
 
-    @init_state
+        self._trace.rollup_fields["rollup.%s" % name] += value
+
     def add_trace_field(self, name, value):
         # prefix with app to avoid key conflicts
         key = "app.%s" % name
-        self._state.trace_fields[key] = value
         # also add to current span
         self.add_context_field(key, value)
 
-    @init_state
+        if not self._trace:
+            log('warning: adding trace field without an active trace')
+            return
+        self._trace.fields[key] = value
+
     def remove_trace_field(self, name):
         key = "app.%s" % name
-        if key in self._state.trace_fields:
-            del self._state.trace_fields[key]
         self.remove_context_field(key)
+        if not self._trace:
+            log('warning: removing trace field without an active trace')
+            return
+        self._trace.fields.pop(key)
 
-    @init_state
     def marshal_trace_context(self):
-        if not self._state.trace_id:
+        if not self._trace:
             log('warning: marshal_trace_context called, but no active trace')
             return
 
         return marshal_trace_context(
-            self._state.trace_id,
-            self._state.stack[-1].id,
-            self._state.trace_fields
+            self._trace.id,
+            self._trace.stack[-1].id,
+            self._trace.fields
         )
 
     def register_hooks(self, presend=None, sampler=None):

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import sys
 from setuptools import setup, find_packages
 
 setup(
@@ -22,6 +21,6 @@ setup(
         'django<2; python_version == "2.7"',
         'django>=2; python_version >= "3.0"',
     ],
-    test_suite='beeline',
+    test_suite='beeline.test_suite.get_test_suite',
     zip_safe=False
 )


### PR DESCRIPTION
This change adds `AsyncioTracer`, which is chosen instead of
`SynchronousTracer` as the tracer implementation if beeline is
initialized from within an `asyncio` event loop.

`AsyncioTracer` stores its trace state in a context variable instead
of in thread local storage. This requires the `contextvars` module,
which was added in Python 3.7. Otherwise the implementation is shared
with `SynchronousTracer`. The trace state implementation is moved into
the `Trace` class to support both implementations.

Context variable assignments are unique per `asyncio` task, allowing
separate trace state per task. New tasks automatically receive the
same context variable bindings when they are created, which is not
what you want for the trace state, since they need to be able to
diverge between tasks. To fix this, `AsyncioTracer` sets up a task
factory on the event loop that creates a copy of the trace state for
each task. The task factory chain-calls to the previous one, if one
happens to already be configured.

A new `beeline.untraced` function decorator is added, to avoid
automatically sharing trace state for `asyncio` tasks that are meant
to be unrelated.

The async code requires syntax that is incompatible with Python 2.7,
and modules of which all aren't available until Python 3.7. The code
itself checks for the necessary features by handling `ImportError`.
The test suite/CI jobs now have separate configurations depending on
the Python version.
