### PR TITLE
Fixes AttributeError when cursor.lastrowid doesn't exist

### DIFF
--- a/beeline/middleware/flask/__init__.py
+++ b/beeline/middleware/flask/__init__.py
@@ -148,7 +148,7 @@ class HoneyDBMiddleware(object):
 
         beeline.add_context({
             "db.duration": query_duration.total_seconds() * 1000,
-            "db.last_insert_id": cursor.lastrowid,
+            "db.last_insert_id": getattr(cursor, 'lastrowid', None),
             "db.rows_affected": cursor.rowcount,
         })
         if self.state.span:


### PR DESCRIPTION
This is the case when using PyODBC and maybe others

Fixes #90 