### PR TITLE
Fix a comment in the _should_sample function: the first 4 bytes are taken not the last 4

### DIFF
--- a/beeline/trace.py
+++ b/beeline/trace.py
@@ -307,7 +307,7 @@ def _should_sample(trace_id, sample_rate):
     # compute a sha1
     sha1 = hashlib.sha1()
     sha1.update(trace_id.encode('utf-8'))
-    # convert last 4 digits to int
+    # convert first 4 digits to int
     value, = struct.unpack('>I', sha1.digest()[:4])
     if value < sample_upper_bound:
         return True


### PR DESCRIPTION
It looks like the behavior of _should_sample [was fixed a while back](https://github.com/honeycombio/beeline-python/commit/908942fb838867b2ab9b40c090f0374091c5b410) but the comment wasn't updated to reflect that. 


Signed-off-by: Irving Popovetsky <irving@honeycomb.io>