### PR TITLE
add check if the app prefix exists

### DIFF
--- a/beeline/trace.py
+++ b/beeline/trace.py
@@ -205,7 +205,9 @@ class Tracer(object):
 
     def add_trace_field(self, name, value):
         # prefix with app to avoid key conflicts
-        key = "app.%s" % name
+        # add the app prefix if it's missing
+        if not name.startswith("app."):
+            key = "app.%s" % name
         # also add to current span
         self.add_context_field(key, value)
 


### PR DESCRIPTION
When reserving a trace_field from CTX the names all ready start with the prefix app. so we receive duplicate prefix **app.app.**

example:
AWS lambda x is using **add_trace_field("id", "i-1")**  (in honeycomb we will see it as **app.id** as expected).
lambda x sending its CTX to lambda y, in honeycomb we will see **app.app.id** and not **app.id** as expected