### PR TITLE
http header hooks

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = False
-current_version = 2.12.2
+current_version = 2.13.0-dev0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}{build}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-We have added new functionality for `http_trace_parse_hook` and `http_trace_propagation_hook`. These features allow beeline users to process incoming tracing-related headers, allowing for eventual interoperability between beelines, OpenTelemetry and AWS tracing.
+We have added new functionality for `http_trace_parse_hook` and `http_trace_propagation_hook`. These features allow beeline users to process incoming tracing-related headers, allowing for eventual interoperability between Honeycomb, OpenTelemetry (W3C) and other tracing formats.
 
 - New `beeline` configuration parameters for `http_trace_parse_hook` and `http_trace_propagation_hook`
 - New `propagate_and_start_trace` function for use by middleware to invoke the `http_trace_parse_hook`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # beeline-python changelog
 
+## 2.13.0
+
+### Features
+
+We have added new functionality for `http_trace_parse_hook` and `http_trace_propagation_hook`. These features allow beeline users to process incoming tracing-related headers, allowing for eventual interoperability between beelines, OpenTelemetry and AWS tracing.
+
+- New `beeline` configuration parameters for `http_trace_parse_hook` and `http_trace_propagation_hook`
+- New `propagate_and_start_trace` function for use by middleware to invoke the `http_trace_parse_hook`
+- New `beeline.propagation` package to centralize propagation-related classes and functions.
+- Implemented `beeline.propagation.Request` classes for middleware to aid in support of header and propagation hooks.
+- Migrateed existing middleware to use new `beeline.propagation` classes and functions so that they support `http_trace_parse_hooks`.
+- Centralized duplicated code for WSGI variants (Flask, Bottle, Werkzeug) into a single place.
+- Added `http_trace_propagation_hook` support to requests and urllib.
+- Deprecate the existing, misnamed `trace_context` related functions, and migrate all internal usage to the new `beeline.propagation.honeycomb` functions. These will be removed when the next major version of the beeline is released.
+
+### Fixes
+
+- Fixed a bug where `urllib.request.urlopen` would fail if given a string URL as an argument.
+
 ## 2.12.2
 
 Improvements

--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -577,16 +577,16 @@ def finish_span(span):
         bl.tracer_impl.finish_span(span=span)
 
 
-def propagate_and_start_trace(context, headers):
+def propagate_and_start_trace(context, request):
     '''
-    Given headers, calls the header_parse hooks to propagate information from the
-    incoming http (or similar) request context, returning a new trace using that
-    information if it exists.
+    Given context and a beeline.propagation.Request subclass, calls the header_parse hooks
+    to propagate information from the incoming http (or similar) request context,
+    returning a new trace using that information if it exists.
     '''
     bl = get_beeline()
 
     if bl:
-        return bl.tracer_impl.propagate_and_start_trace(context, headers)
+        return bl.tracer_impl.propagate_and_start_trace(context, request)
     return None
 
 

--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -9,6 +9,7 @@ from libhoney import Client
 from beeline.trace import SynchronousTracer
 from beeline.version import VERSION
 from beeline import internal
+from beeline.propagation import honeycomb_http_trace_parser_hook, honeycomb_http_trace_propagation_hook
 # pyflakes
 assert internal
 
@@ -57,7 +58,7 @@ class Beeline(object):
                  max_concurrent_batches=10, max_batch_size=100, send_frequency=0.25,
                  block_on_send=False, block_on_response=False,
                  transmission_impl=None, sampler_hook=None, presend_hook=None,
-                 http_trace_parser_hook=None, http_trace_propagation_hook=None,
+                 http_trace_parser_hook=honeycomb_http_trace_parser_hook, http_trace_propagation_hook=honeycomb_http_trace_propagation_hook,
                  debug=False):
 
         self.client = None
@@ -603,7 +604,7 @@ def http_trace_propagation_hook():
     bl = get_beeline()
 
     if bl:
-        return bl.tracer_impl.http_trace_propagation_hook(bl.tracer_impl.propagation_context)
+        return bl.tracer_impl.http_trace_propagation_hook(bl.tracer_impl.get_propagation_context())
 
 
 def marshal_trace_context():

--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -9,7 +9,7 @@ from libhoney import Client
 from beeline.trace import SynchronousTracer
 from beeline.version import VERSION
 from beeline import internal
-from beeline.propagation.honeycomb import http_trace_parser_hook, http_trace_propagation_hook
+import beeline.propagation.honeycomb
 # pyflakes
 assert internal
 
@@ -58,7 +58,8 @@ class Beeline(object):
                  max_concurrent_batches=10, max_batch_size=100, send_frequency=0.25,
                  block_on_send=False, block_on_response=False,
                  transmission_impl=None, sampler_hook=None, presend_hook=None,
-                 http_trace_parser_hook=http_trace_parser_hook, http_trace_propagation_hook=http_trace_propagation_hook,
+                 http_trace_parser_hook=beeline.propagation.honeycomb.http_trace_parser_hook,
+                 http_trace_propagation_hook=beeline.propagation.honeycomb.http_trace_propagation_hook,
                  debug=False):
 
         self.client = None
@@ -582,7 +583,8 @@ def propagate_and_start_trace(context, headers):
     bl = get_beeline()
 
     if bl:
-        bl.tracer_impl.propagate_and_start_trace(context, headers)
+        return bl.tracer_impl.propagate_and_start_trace(context, headers)
+    return None
 
 
 def http_trace_parser_hook(headers):
@@ -595,6 +597,7 @@ def http_trace_parser_hook(headers):
 
     if bl:
         return bl.tracer_impl.http_trace_parser_hook(headers)
+    return None
 
 
 def http_trace_propagation_hook():
@@ -607,6 +610,7 @@ def http_trace_propagation_hook():
 
     if bl:
         return bl.tracer_impl.http_trace_propagation_hook(bl.tracer_impl.get_propagation_context())
+    return None
 
 
 def marshal_trace_context():
@@ -627,6 +631,7 @@ def marshal_trace_context():
 
     if bl:
         return bl.tracer_impl.marshal_trace_context()
+    return None
 
 
 def new_event(data=None, trace_name=''):

--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -9,7 +9,7 @@ from libhoney import Client
 from beeline.trace import SynchronousTracer
 from beeline.version import VERSION
 from beeline import internal
-from beeline.propagation import honeycomb_http_trace_parser_hook, honeycomb_http_trace_propagation_hook
+from beeline.propagation.honeycomb import http_trace_parser_hook, http_trace_propagation_hook
 # pyflakes
 assert internal
 
@@ -58,7 +58,7 @@ class Beeline(object):
                  max_concurrent_batches=10, max_batch_size=100, send_frequency=0.25,
                  block_on_send=False, block_on_response=False,
                  transmission_impl=None, sampler_hook=None, presend_hook=None,
-                 http_trace_parser_hook=honeycomb_http_trace_parser_hook, http_trace_propagation_hook=honeycomb_http_trace_propagation_hook,
+                 http_trace_parser_hook=http_trace_parser_hook, http_trace_propagation_hook=http_trace_propagation_hook,
                  debug=False):
 
         self.client = None
@@ -496,9 +496,11 @@ def tracer(name, trace_id=None, parent_id=None):
 def start_trace(context=None, trace_id=None, parent_span_id=None):
     '''
     Start a trace, returning the root span. To finish the trace, pass the span
-    to `finish_trace`. If you are using the beeline middleware plugins, such as for
-    django, flask, or AWS lambda, you will want to use `start_span` instead, as
-    `start_trace` is called at the start of the request.
+    to `finish_trace`. `start_trace` does not propagate contexts - if you wish
+    to propagate contexts from sources such as HTTP headers, use `propagate_and_start_trace`
+    instead. If you are using the beeline middleware plugins, such as fordjango,
+    flask, or AWS lambda, you will want to use `start_span` instead, as `start_trace`
+    is called at the start of the request.
 
     Args:
     - `context`: optional dictionary of event fields to populate the root span with

--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -111,7 +111,10 @@ class Beeline(object):
         else:
             self.tracer_impl = SynchronousTracer(self.client)
         self.tracer_impl.register_hooks(
-            presend=presend_hook, sampler=sampler_hook, http_trace_parser=http_trace_parser_hook, http_trace_propagation=http_trace_propagation_hook)
+            presend=presend_hook,
+            sampler=sampler_hook,
+            http_trace_parser=http_trace_parser_hook,
+            http_trace_propagation=http_trace_propagation_hook)
         self.sampler_hook = sampler_hook
         self.presend_hook = presend_hook
         self.http_trace_parser_hook = http_trace_parser_hook

--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -615,7 +615,7 @@ def http_trace_propagation_hook():
     if bl:
         try:
             return bl.tracer_impl.http_trace_propagation_hook(bl.tracer_impl.get_propagation_context())
-        except:
+        except Exception:
             err = sys.exc_info()
             bl.log('error: http_trace_propagation_hook returned exception: %s', err)
     return None

--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -10,6 +10,7 @@ from beeline.trace import SynchronousTracer
 from beeline.version import VERSION
 from beeline import internal
 import beeline.propagation.honeycomb
+import sys
 # pyflakes
 assert internal
 
@@ -612,7 +613,11 @@ def http_trace_propagation_hook():
     bl = get_beeline()
 
     if bl:
-        return bl.tracer_impl.http_trace_propagation_hook(bl.tracer_impl.get_propagation_context())
+        try:
+            return bl.tracer_impl.http_trace_propagation_hook(bl.tracer_impl.get_propagation_context())
+        except:
+            err = sys.exc_info()
+            bl.log('error: http_trace_propagation_hook returned exception: %s', err)
     return None
 
 

--- a/beeline/middleware/awslambda/__init__.py
+++ b/beeline/middleware/awslambda/__init__.py
@@ -1,6 +1,5 @@
 import beeline
-from beeline.propagation import honeycomb_unmarshal_trace_context
-
+from beeline.propagation import PropagationHeaders
 # In Lambda, a cold start is when Lambda has to spin up a new instance of a
 # function to satisfy a request, rather than re-use an existing instance.
 # This usually has a non-trivial effect on latency for the request and is
@@ -8,71 +7,59 @@ from beeline.propagation import honeycomb_unmarshal_trace_context
 COLD_START = True
 
 
-def _get_trace_data_from_message_attributes(attributes):
-    ''' Look for the trace data from SNS/SQS Messsage Atrributes
+class LambdaHeaders(PropagationHeaders):
     '''
-    trace_id, parent_id, context = None, None, None
+    Look for header values in SNS/SQS Message Attributes
+    '''
 
-    if isinstance(attributes, dict):
-        keymap = {k.lower(): k for k in attributes.keys()}
-        if 'x-honeycomb-trace' in keymap:
-            if 'Value' in attributes[keymap['x-honeycomb-trace']]:
-                # SNS
-                trace_id, parent_id, context = honeycomb_unmarshal_trace_context(
-                    attributes[keymap['x-honeycomb-trace']]['Value']
-                )
-            elif 'stringValue' in attributes[keymap['x-honeycomb-trace']]:
-                # SQS
-                trace_id, parent_id, context = honeycomb_unmarshal_trace_context(
-                    attributes[keymap['x-honeycomb-trace']]['stringValue']
-                )
+    def __init__(self, event):
+        # Look for headers (or equivalents) in common places
+        self._type = None
+        if isinstance(event, dict):
+            # If API gateway is triggering the Lambda, the event will have headers
+            # and we can look for our trace headers
+            # https://docs.aws.amazon.com/lambda/latest/dg/with-on-demand-https.html
+            if 'headers' in event:
+                if isinstance(event['headers'], dict):
+                    self._attributes = event['headers']
+                    self._type = 'headers'
 
-    return trace_id, parent_id, context
+            # If a message source is triggering the Lambda, the event may have
+            # our trace data in the message attributes
+            elif 'Records' in event:
+                # Only process batches of exactly 1
+                #  Higher batch sizes would have multiple messages thus
+                #  generating multiple traces and requiring manual instrumentation
+                if len(event['Records']) == 1:
+                    # If SNS is triggering the Lambda
+                    # https://docs.aws.amazon.com/lambda/latest/dg/with-sns.html
+                    if 'EventSource' in event['Records'][0]:
+                        if event['Records'][0]['EventSource'] == 'aws:sns':
+                            self._attributes = event['Records'][0]['Sns']['MessageAttributes']
+                            self._type = 'sns'
+                    # If SQS is triggering the Lambda
+                    # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html
+                    elif 'eventSource' in event['Records'][0]:
+                        if event['Records'][0]['eventSource'] == 'aws:sqs':
+                            self._attributes = event['Records'][0]['messageAttributes']
+                            self._type = 'sqs'
+            if self._type:
+                self._keymap = {k.lower(): k for k in self._attributes.keys()}
 
-
-def _get_trace_data(event):
-    ''' Extract trace/parent ids and context object that are threaded through
-    in various ways from other beelines'''
-    trace_id, parent_id, context = None, None, None
-
-    # Look for trace headers in common places
-    if isinstance(event, dict):
-        # If API gateway is triggering the Lambda, the event will have headers
-        # and we can look for our trace headers
-        # https://docs.aws.amazon.com/lambda/latest/dg/with-on-demand-https.html
-        if 'headers' in event:
-            if isinstance(event['headers'], dict):
-                # deal with possible case issues
-                keymap = {k.lower(): k for k in event['headers'].keys()}
-                if 'x-honeycomb-trace' in keymap:
-                    trace_id, parent_id, context = honeycomb_unmarshal_trace_context(
-                        event['headers'][keymap['x-honeycomb-trace']]
-                    )
-
-        # If a message source is triggering the Lambda, the event may have
-        # our trace data in the message attributes
-        elif 'Records' in event:
-            # Only process batches of exactly 1
-            #  Higher batch sizes would have multiple messages thus
-            #  generating multiple traces and requiring manual instrumentation
-            if len(event['Records']) == 1:
-                # If SNS is triggering the Lambda
-                # https://docs.aws.amazon.com/lambda/latest/dg/with-sns.html
-                if 'EventSource' in event['Records'][0]:
-                    if event['Records'][0]['EventSource'] == 'aws:sns':
-                        trace_id, parent_id, context = _get_trace_data_from_message_attributes(
-                            event['Records'][0]['Sns']['MessageAttributes']
-                        )
-
-                # If SQS is triggering the Lambda
-                # https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html
-                elif 'eventSource' in event['Records'][0]:
-                    if event['Records'][0]['eventSource'] == 'aws:sqs':
-                        trace_id, parent_id, context = _get_trace_data_from_message_attributes(
-                            event['Records'][0]['messageAttributes']
-                        )
-
-    return trace_id, parent_id, context
+    def get(self, key):
+        if not self._type:
+            return None
+        lookup_key = key.lower()
+        if not lookup_key in self._keymap:
+            return None
+        lookup_key = self._keymap[lookup_key]
+        if self._type == 'headers':
+            return self._attributes[lookup_key]
+        elif self._type == 'sns':
+            return self._attributes[lookup_key]['Value']
+        elif self._type == 'sqs':
+            return self._attributes[lookup_key]['stringValue']
+        return None
 
 
 def beeline_wrapper(handler):
@@ -98,39 +85,33 @@ def beeline_wrapper(handler):
         if not beeline.get_beeline():
             return handler(event, context)
 
+        root_span = None
         try:
-            # assume we're going to get bad values sometimes in our headers
-            trace_id, parent_id, trace_context = None, None, None
-            try:
-                trace_id, parent_id, trace_context = _get_trace_data(event)
-            except Exception as e:
-                beeline.internal.log(
-                    'error attempting to extract trace context: %s', beeline.internal.stringify_exception(e))
-                pass
-            with beeline.tracer(name=handler.__name__,
-                                trace_id=trace_id, parent_id=parent_id):
-                beeline.add_context({
-                    "app.function_name": getattr(context, 'function_name', ""),
-                    "app.function_version": getattr(context, 'function_version', ""),
-                    "app.request_id": getattr(context, 'aws_request_id', ""),
-                    "app.event": event,
-                    "meta.cold_start": COLD_START,
-                })
+            # Create request context
+            request_context = {
+                "app.function_name": getattr(context, 'function_name', ""),
+                "app.function_version": getattr(context, 'function_version', ""),
+                "app.request_id": getattr(context, 'aws_request_id', ""),
+                "app.event": event,
+                "meta.cold_start": COLD_START,
+                "name": handler.__name__
+            }
 
-                # if there is custom context attached from upstream, add that now
-                if isinstance(trace_context, dict):
-                    for k, v in trace_context.items():
-                        beeline.add_trace_field(k, v)
+            headers = LambdaHeaders(event)
+            root_span = beeline.propagate_and_start_trace(
+                request_context, headers)
 
-                resp = handler(event, context)
+            # Actually run the handler
+            resp = handler(event, context)
 
-                if resp is not None:
-                    beeline.add_context_field('app.response', resp)
+            if resp is not None:
+                beeline.add_context_field('app.response', resp)
 
-                return resp
+            return resp
         finally:
             # This remains false for the lifetime of the module
             COLD_START = False
+            beeline.finish_trace(root_span)
             # we have to flush events before the lambda returns
             beeline.get_beeline().client.flush()
 

--- a/beeline/middleware/awslambda/__init__.py
+++ b/beeline/middleware/awslambda/__init__.py
@@ -1,5 +1,5 @@
 import beeline
-from beeline.trace import unmarshal_trace_context
+from beeline.propagation import honeycomb_unmarshal_trace_context
 
 # In Lambda, a cold start is when Lambda has to spin up a new instance of a
 # function to satisfy a request, rather than re-use an existing instance.
@@ -18,12 +18,12 @@ def _get_trace_data_from_message_attributes(attributes):
         if 'x-honeycomb-trace' in keymap:
             if 'Value' in attributes[keymap['x-honeycomb-trace']]:
                 # SNS
-                trace_id, parent_id, context = unmarshal_trace_context(
+                trace_id, parent_id, context = honeycomb_unmarshal_trace_context(
                     attributes[keymap['x-honeycomb-trace']]['Value']
                 )
             elif 'stringValue' in attributes[keymap['x-honeycomb-trace']]:
                 # SQS
-                trace_id, parent_id, context = unmarshal_trace_context(
+                trace_id, parent_id, context = honeycomb_unmarshal_trace_context(
                     attributes[keymap['x-honeycomb-trace']]['stringValue']
                 )
 
@@ -45,7 +45,7 @@ def _get_trace_data(event):
                 # deal with possible case issues
                 keymap = {k.lower(): k for k in event['headers'].keys()}
                 if 'x-honeycomb-trace' in keymap:
-                    trace_id, parent_id, context = unmarshal_trace_context(
+                    trace_id, parent_id, context = honeycomb_unmarshal_trace_context(
                         event['headers'][keymap['x-honeycomb-trace']]
                     )
 

--- a/beeline/middleware/awslambda/__init__.py
+++ b/beeline/middleware/awslambda/__init__.py
@@ -51,7 +51,7 @@ class LambdaRequest(Request):
         if not self._type:
             return None
         lookup_key = key.lower()
-        if not lookup_key in self._keymap:
+        if lookup_key not in self._keymap:
             return None
         lookup_key = self._keymap[lookup_key]
         if self._type == 'headers':

--- a/beeline/middleware/awslambda/test_awslambda.py
+++ b/beeline/middleware/awslambda/test_awslambda.py
@@ -17,9 +17,9 @@ class TestGetTraceIds(unittest.TestCase):
             },
         }
 
-        headers = awslambda.LambdaHeaders(event)
-        self.assertIsNotNone(headers)
-        self.assertEqual(headers.get('X-Honeycomb-Trace'), header_value)
+        lr = awslambda.LambdaRequest(event)
+        self.assertIsNotNone(lr)
+        self.assertEqual(lr.header('X-Honeycomb-Trace'), header_value)
 
     def test_get_trace_ids_no_header(self):
         ''' ensure that we handle events with no header key '''
@@ -27,9 +27,9 @@ class TestGetTraceIds(unittest.TestCase):
             'foo': 1,
         }
 
-        headers = awslambda.LambdaHeaders(event)
-        self.assertIsNotNone(headers)
-        self.assertIsNone(headers.get('X-Honeycomb-Trace'))
+        lr = awslambda.LambdaRequest(event)
+        self.assertIsNotNone(lr)
+        self.assertIsNone(lr.header('X-Honeycomb-Trace'))
 
     def test_get_trace_ids_sns_none(self):
         ''' ensure that we handle SNS events with no honeycomb key '''
@@ -46,9 +46,9 @@ class TestGetTraceIds(unittest.TestCase):
             ],
         }
 
-        headers = awslambda.LambdaHeaders(event)
-        self.assertIsNotNone(headers)
-        self.assertIsNone(headers.get('X-Honeycomb-Trace'))
+        lr = awslambda.LambdaRequest(event)
+        self.assertIsNotNone(lr)
+        self.assertIsNone(lr.header('X-Honeycomb-Trace'))
 
     def test_get_trace_ids_sns_attribute(self):
         ''' ensure that we extract SNS data from message attributes'''
@@ -70,9 +70,9 @@ class TestGetTraceIds(unittest.TestCase):
             ],
         }
 
-        headers = awslambda.LambdaHeaders(event)
-        self.assertIsNotNone(headers)
-        self.assertEqual(headers.get('X-Honeycomb-Trace'), header_value)
+        lr = awslambda.LambdaRequest(event)
+        self.assertIsNotNone(lr)
+        self.assertEqual(lr.header('X-Honeycomb-Trace'), header_value)
 
     def test_get_trace_ids_sqs_none(self):
         ''' ensure that we handle SQS events with no honeycomb key '''
@@ -87,9 +87,9 @@ class TestGetTraceIds(unittest.TestCase):
             ],
         }
 
-        headers = awslambda.LambdaHeaders(event)
-        self.assertIsNotNone(headers)
-        self.assertIsNone(headers.get('X-Honeycomb-Trace'))
+        lr = awslambda.LambdaRequest(event)
+        self.assertIsNotNone(lr)
+        self.assertIsNone(lr.header('X-Honeycomb-Trace'))
 
     def test_get_trace_ids_sqs_attributes(self):
         ''' ensure that we extract SQS data from message attributes'''
@@ -113,9 +113,9 @@ class TestGetTraceIds(unittest.TestCase):
             ],
         }
 
-        headers = awslambda.LambdaHeaders(event)
-        self.assertIsNotNone(headers)
-        self.assertEqual(headers.get('X-Honeycomb-Trace'), header_value)
+        lr = awslambda.LambdaRequest(event)
+        self.assertIsNotNone(lr)
+        self.assertEqual(lr.header('X-Honeycomb-Trace'), header_value)
 
     def test_message_batch_is_ignored(self):
         ''' ensure that we don't process batches'''
@@ -153,9 +153,9 @@ class TestGetTraceIds(unittest.TestCase):
             ],
         }
 
-        headers = awslambda.LambdaHeaders(event)
-        self.assertIsNotNone(headers)
-        self.assertIsNone(headers.get('X-Honeycomb-Trace'))
+        lr = awslambda.LambdaRequest(event)
+        self.assertIsNotNone(lr)
+        self.assertIsNone(lr.header('X-Honeycomb-Trace'))
 
 
 class TestLambdaWrapper(unittest.TestCase):

--- a/beeline/middleware/awslambda/test_awslambda.py
+++ b/beeline/middleware/awslambda/test_awslambda.py
@@ -6,10 +6,11 @@ from beeline.middleware import awslambda
 header_value = '1;trace_id=bloop,parent_id=scoop,context=e30K'
 
 
-class TestGetTraceIds(unittest.TestCase):
-
-    def test_get_trace_ids_from_header(self):
-        ''' test that trace_id and parent_id are extracted regardless of case '''
+class TestLambdaRequest(unittest.TestCase):
+    def test_get_header_from_headers(self):
+        '''
+        Test that if headers is set, we have case-insensitive match.
+        '''
         event = {
             'headers': {
                 # case shouldn't matter
@@ -21,7 +22,7 @@ class TestGetTraceIds(unittest.TestCase):
         self.assertIsNotNone(lr)
         self.assertEqual(lr.header('X-Honeycomb-Trace'), header_value)
 
-    def test_get_trace_ids_no_header(self):
+    def test_handle_no_headers(self):
         ''' ensure that we handle events with no header key '''
         event = {
             'foo': 1,
@@ -31,7 +32,7 @@ class TestGetTraceIds(unittest.TestCase):
         self.assertIsNotNone(lr)
         self.assertIsNone(lr.header('X-Honeycomb-Trace'))
 
-    def test_get_trace_ids_sns_none(self):
+    def test_handle_sns_none(self):
         ''' ensure that we handle SNS events with no honeycomb key '''
         event = {
             "Records":
@@ -50,7 +51,7 @@ class TestGetTraceIds(unittest.TestCase):
         self.assertIsNotNone(lr)
         self.assertIsNone(lr.header('X-Honeycomb-Trace'))
 
-    def test_get_trace_ids_sns_attribute(self):
+    def test_handle_sns_attribute(self):
         ''' ensure that we extract SNS data from message attributes'''
         event = {
             "Records":
@@ -74,7 +75,7 @@ class TestGetTraceIds(unittest.TestCase):
         self.assertIsNotNone(lr)
         self.assertEqual(lr.header('X-Honeycomb-Trace'), header_value)
 
-    def test_get_trace_ids_sqs_none(self):
+    def test_handle_sqs_none(self):
         ''' ensure that we handle SQS events with no honeycomb key '''
         event = {
             "Records":
@@ -91,7 +92,7 @@ class TestGetTraceIds(unittest.TestCase):
         self.assertIsNotNone(lr)
         self.assertIsNone(lr.header('X-Honeycomb-Trace'))
 
-    def test_get_trace_ids_sqs_attributes(self):
+    def test_handle_sqs_attributes(self):
         ''' ensure that we extract SQS data from message attributes'''
         event = {
             "Records":

--- a/beeline/middleware/awslambda/test_awslambda.py
+++ b/beeline/middleware/awslambda/test_awslambda.py
@@ -1,23 +1,25 @@
 import unittest
-from mock import Mock, patch
+from mock import Mock, patch, ANY
 
 from beeline.middleware import awslambda
 
+header_value = '1;trace_id=bloop,parent_id=scoop,context=e30K'
+
 
 class TestGetTraceIds(unittest.TestCase):
+
     def test_get_trace_ids_from_header(self):
         ''' test that trace_id and parent_id are extracted regardless of case '''
         event = {
             'headers': {
                 # case shouldn't matter
-                'X-HoNEyComb-TrACE': '1;trace_id=bloop,parent_id=scoop,context=e30K',
+                'X-HoNEyComb-TrACE': header_value,
             },
         }
 
-        trace_id, parent_id, context = awslambda._get_trace_data(event)
-        self.assertEqual(trace_id, 'bloop')
-        self.assertEqual(parent_id, 'scoop')
-        self.assertEqual(context, {})
+        headers = awslambda.LambdaHeaders(event)
+        self.assertIsNotNone(headers)
+        self.assertEqual(headers.get('X-Honeycomb-Trace'), header_value)
 
     def test_get_trace_ids_no_header(self):
         ''' ensure that we handle events with no header key '''
@@ -25,10 +27,9 @@ class TestGetTraceIds(unittest.TestCase):
             'foo': 1,
         }
 
-        trace_id, parent_id, context = awslambda._get_trace_data(event)
-        self.assertIsNone(trace_id)
-        self.assertIsNone(parent_id)
-        self.assertIsNone(context)
+        headers = awslambda.LambdaHeaders(event)
+        self.assertIsNotNone(headers)
+        self.assertIsNone(headers.get('X-Honeycomb-Trace'))
 
     def test_get_trace_ids_sns_none(self):
         ''' ensure that we handle SNS events with no honeycomb key '''
@@ -45,10 +46,9 @@ class TestGetTraceIds(unittest.TestCase):
             ],
         }
 
-        trace_id, parent_id, context = awslambda._get_trace_data(event)
-        self.assertIsNone(trace_id)
-        self.assertIsNone(parent_id)
-        self.assertIsNone(context)
+        headers = awslambda.LambdaHeaders(event)
+        self.assertIsNotNone(headers)
+        self.assertIsNone(headers.get('X-Honeycomb-Trace'))
 
     def test_get_trace_ids_sns_attribute(self):
         ''' ensure that we extract SNS data from message attributes'''
@@ -62,7 +62,7 @@ class TestGetTraceIds(unittest.TestCase):
                         "MessageAttributes": {
                             'X-HoNEyComb-TrACE': {
                                 "Type": "String",
-                                "Value": "1;trace_id=bloop,parent_id=scoop,context=e30K",
+                                "Value": header_value,
                             }
                         }
                     }
@@ -70,10 +70,9 @@ class TestGetTraceIds(unittest.TestCase):
             ],
         }
 
-        trace_id, parent_id, context = awslambda._get_trace_data(event)
-        self.assertEqual(trace_id, 'bloop')
-        self.assertEqual(parent_id, 'scoop')
-        self.assertEqual(context, {})
+        headers = awslambda.LambdaHeaders(event)
+        self.assertIsNotNone(headers)
+        self.assertEqual(headers.get('X-Honeycomb-Trace'), header_value)
 
     def test_get_trace_ids_sqs_none(self):
         ''' ensure that we handle SQS events with no honeycomb key '''
@@ -88,10 +87,9 @@ class TestGetTraceIds(unittest.TestCase):
             ],
         }
 
-        trace_id, parent_id, context = awslambda._get_trace_data(event)
-        self.assertIsNone(trace_id)
-        self.assertIsNone(parent_id)
-        self.assertIsNone(context)
+        headers = awslambda.LambdaHeaders(event)
+        self.assertIsNotNone(headers)
+        self.assertIsNone(headers.get('X-Honeycomb-Trace'))
 
     def test_get_trace_ids_sqs_attributes(self):
         ''' ensure that we extract SQS data from message attributes'''
@@ -103,7 +101,7 @@ class TestGetTraceIds(unittest.TestCase):
                     "messageAttributes": {
                         'X-HoNEyComb-TrACE': {
                             "Type": "String",
-                            "stringValue": "1;trace_id=bloop,parent_id=scoop,context=e30K",
+                            "stringValue": header_value,
                         },
                         'foo': {
                             "Type": "String",
@@ -115,10 +113,9 @@ class TestGetTraceIds(unittest.TestCase):
             ],
         }
 
-        trace_id, parent_id, context = awslambda._get_trace_data(event)
-        self.assertEqual(trace_id, 'bloop')
-        self.assertEqual(parent_id, 'scoop')
-        self.assertEqual(context, {})
+        headers = awslambda.LambdaHeaders(event)
+        self.assertIsNotNone(headers)
+        self.assertEqual(headers.get('X-Honeycomb-Trace'), header_value)
 
     def test_message_batch_is_ignored(self):
         ''' ensure that we don't process batches'''
@@ -156,10 +153,9 @@ class TestGetTraceIds(unittest.TestCase):
             ],
         }
 
-        trace_id, parent_id, context = awslambda._get_trace_data(event)
-        self.assertIsNone(trace_id)
-        self.assertIsNone(parent_id)
-        self.assertIsNone(context)
+        headers = awslambda.LambdaHeaders(event)
+        self.assertIsNotNone(headers)
+        self.assertIsNone(headers.get('X-Honeycomb-Trace'))
 
 
 class TestLambdaWrapper(unittest.TestCase):
@@ -178,7 +174,7 @@ class TestLambdaWrapper(unittest.TestCase):
 
     def test_basic_instrumentation(self):
         ''' ensure basic event fields get instrumented '''
-        with patch('beeline.middleware.awslambda.beeline.add_context') as m_add,\
+        with patch('beeline.propagate_and_start_trace') as m_propagate,\
                 patch('beeline.middleware.awslambda.beeline._GBL'),\
                 patch('beeline.middleware.awslambda.COLD_START') as m_cold_start:
             m_event = Mock()
@@ -190,10 +186,10 @@ class TestLambdaWrapper(unittest.TestCase):
                 return 1
 
             self.assertEqual(handler(m_event, m_context), 1)
-            m_add.assert_called_once_with({
-                "app.function_name": m_context.function_name,
-                "app.function_version": m_context.function_version,
-                "app.request_id": m_context.aws_request_id,
-                "app.event": m_event,
-                "meta.cold_start": m_cold_start,
-            })
+            m_propagate.assert_called_once_with({
+                'app.function_name': 'fn',
+                'app.function_version': '1.1.1',
+                'app.request_id': '12345',
+                'app.event': ANY,
+                'meta.cold_start': ANY,
+                'name': 'handler'}, ANY)

--- a/beeline/middleware/bottle/__init__.py
+++ b/beeline/middleware/bottle/__init__.py
@@ -1,6 +1,6 @@
 import beeline
 from beeline.propagation import Request
-from beeline.middleware.werkzeug import WerkzeugRequest
+from beeline.middleware.wsgi import WSGIRequest
 
 
 class HoneyWSGIMiddleware(object):
@@ -9,9 +9,9 @@ class HoneyWSGIMiddleware(object):
         self.app = app
 
     def __call__(self, environ, start_response):
-        wr = WerkzeugRequest(environ)
-        request_context = self.get_context_from_environ(environ)
-        root_span = beeline.propagate_and_start_trace(request_context, wr)
+        wr = WSGIRequest("bottle", environ)
+
+        root_span = beeline.propagate_and_start_trace(wr.request_context(), wr)
 
         def _start_response(status, headers, *args):
             beeline.add_context_field("response.status_code", status)
@@ -20,23 +20,3 @@ class HoneyWSGIMiddleware(object):
             return start_response(status, headers, *args)
 
         return self.app(environ, _start_response)
-
-    def get_context_from_environ(self, environ):
-        request_method = environ.get('REQUEST_METHOD')
-        if request_method:
-            trace_name = "bottle_http_%s" % request_method.lower()
-        else:
-            trace_name = "bottle_http"
-
-        return {
-            "name": trace_name,
-            "type": "http_server",
-            "request.host": environ.get('HTTP_HOST'),
-            "request.method": request_method,
-            "request.path": environ.get('PATH_INFO'),
-            "request.remote_addr": environ.get('REMOTE_ADDR'),
-            "request.content_length": environ.get('CONTENT_LENGTH', 0),
-            "request.user_agent": environ.get('HTTP_USER_AGENT'),
-            "request.scheme": environ.get('wsgi.url_scheme'),
-            "request.query": environ.get('QUERY_STRING')
-        }

--- a/beeline/middleware/bottle/__init__.py
+++ b/beeline/middleware/bottle/__init__.py
@@ -1,15 +1,6 @@
 import beeline
-from beeline.propagation import PropagationHeaders
-
-
-class BottleHeaders(PropagationHeaders):
-    def __init__(self, environ):
-        self._environ = environ
-
-    def get(self, key):
-        # FIXME: Is this .upper strictly necessary? Does environ already do it for us?
-        lookup_key = key.upper().replace('-', '_')
-        return self._environ.get(lookup_key)
+from beeline.propagation import Request
+from beeline.middleware.werkzeug import WerkzeugRequest
 
 
 class HoneyWSGIMiddleware(object):
@@ -18,9 +9,9 @@ class HoneyWSGIMiddleware(object):
         self.app = app
 
     def __call__(self, environ, start_response):
-        headers = BottleHeaders(environ)
+        wr = WerkzeugRequest(environ)
         request_context = self.get_context_from_environ(environ)
-        root_span = beeline.propagate_and_start_trace(request_context, headers)
+        root_span = beeline.propagate_and_start_trace(request_context, wr)
 
         def _start_response(status, headers, *args):
             beeline.add_context_field("response.status_code", status)

--- a/beeline/middleware/bottle/test_bottle.py
+++ b/beeline/middleware/bottle/test_bottle.py
@@ -15,11 +15,11 @@ class SimpleWSGITest(unittest.TestCase):
         mock_resp = Mock()
         mock_trace = Mock()
         mock_environ = {}
-        self.m_gbl.start_trace.return_value = mock_trace
+        self.m_gbl.propagate_and_start_trace.return_value = mock_trace
 
         mw = HoneyWSGIMiddleware(mock_app)
         mw({}, mock_resp)
-        self.m_gbl.start_trace.assert_called_once()
+        self.m_gbl.propagate_and_start_trace.assert_called_once()
 
         mock_app.assert_called_once_with(mock_environ, ANY)
 

--- a/beeline/middleware/django/__init__.py
+++ b/beeline/middleware/django/__init__.py
@@ -1,21 +1,17 @@
 import contextlib
 import datetime
 import beeline
-from beeline.propagation import honeycomb_unmarshal_trace_context
+from beeline.propagation import PropagationHeaders
 from django.db import connections
 
 
-def _get_trace_context(request):
-    trace_context = request.META.get('HTTP_X_HONEYCOMB_TRACE')
-    beeline.internal.log("got trace context: %s", trace_context)
-    if trace_context:
-        try:
-            return honeycomb_unmarshal_trace_context(trace_context)
-        except Exception as e:
-            beeline.internal.log(
-                'error attempting to extract trace context: %s', beeline.internal.stringify_exception(e))
+class DjangoHeaders(PropagationHeaders):
+    def __init__(self, request):
+        self._META = request.META
 
-    return None, None, None
+    def get(self, key):
+        lookup_key = key.upper().replace('-', '_')
+        return self._META.get(lookup_key)
 
 
 class HoneyDBWrapper(object):
@@ -85,17 +81,10 @@ class HoneyMiddlewareBase(object):
     def create_http_event(self, request):
         # Code to be executed for each request before
         # the view (and later middleware) are called.
-
-        trace_id, parent_id, parent_context = _get_trace_context(request)
+        headers = DjangoHeaders(request)
 
         request_context = self.get_context_from_request(request)
-
-        trace = beeline.start_trace(
-            context=request_context, trace_id=trace_id, parent_span_id=parent_id)
-
-        if isinstance(parent_context, dict):
-            for k, v in parent_context.items():
-                beeline.add_trace_field(k, v)
+        root_span = beeline.propagate_and_start_trace(request_context, headers)
 
         response = self.get_response(request)
 
@@ -103,7 +92,7 @@ class HoneyMiddlewareBase(object):
         # the view is called.
         response_context = self.get_context_from_response(request, response)
         beeline.add_context(response_context)
-        beeline.finish_trace(trace)
+        beeline.finish_trace(root_span)
 
         return response
 

--- a/beeline/middleware/django/__init__.py
+++ b/beeline/middleware/django/__init__.py
@@ -1,7 +1,7 @@
 import contextlib
 import datetime
 import beeline
-from beeline.trace import unmarshal_trace_context
+from beeline.propagation import honeycomb_unmarshal_trace_context
 from django.db import connections
 
 
@@ -10,7 +10,7 @@ def _get_trace_context(request):
     beeline.internal.log("got trace context: %s", trace_context)
     if trace_context:
         try:
-            return unmarshal_trace_context(trace_context)
+            return honeycomb_unmarshal_trace_context(trace_context)
         except Exception as e:
             beeline.internal.log(
                 'error attempting to extract trace context: %s', beeline.internal.stringify_exception(e))

--- a/beeline/middleware/django/__init__.py
+++ b/beeline/middleware/django/__init__.py
@@ -9,9 +9,10 @@ class DjangoRequest(Request):
     def __init__(self, request):
         self._request = request
         self._META = request.META
+        beeline.get_beeline().log(request.META)
 
     def header(self, key):
-        lookup_key = key.upper().replace('-', '_')
+        lookup_key = "HTTP_" + key.upper().replace('-', '_')
         return self._request.META.get(lookup_key)
 
     def method(self):

--- a/beeline/middleware/django/test_django.py
+++ b/beeline/middleware/django/test_django.py
@@ -14,11 +14,11 @@ class SimpleWSGITest(unittest.TestCase):
         mock_req = Mock()
         mock_resp = Mock()
         mock_trace = Mock()
-        self.m_gbl.start_trace.return_value = mock_trace
+        self.m_gbl.propagate_and_start_trace.return_value = mock_trace
 
         mw = HoneyMiddlewareBase(mock_resp)
         resp = mw(mock_req)
-        self.m_gbl.start_trace.assert_called_once()
+        self.m_gbl.propagate_and_start_trace.assert_called_once()
 
         mock_resp.assert_called_once_with(mock_req)
 

--- a/beeline/middleware/flask/__init__.py
+++ b/beeline/middleware/flask/__init__.py
@@ -3,7 +3,6 @@ import threading
 
 import beeline
 import flask  # to avoid namespace collision with request vs Request
-from beeline.trace import unmarshal_trace_context
 from beeline.propagation import PropagationHeaders
 from flask import current_app, signals
 # needed to build a request object from environ in the middleware

--- a/beeline/middleware/flask/__init__.py
+++ b/beeline/middleware/flask/__init__.py
@@ -49,7 +49,7 @@ class HoneyWSGIMiddleware(object):
         headers = WerkzeugHeaders(req.headers)
 
         root_span = beeline.propagate_and_start_trace(
-            context=self.get_context_from_environ, headers=headers)
+            self.get_context_from_environ, headers)
 
         def _start_response(status, headers, *args):
             status_code = int(status[0:4])

--- a/beeline/middleware/flask/test_flask.py
+++ b/beeline/middleware/flask/test_flask.py
@@ -15,11 +15,11 @@ class SimpleWSGITest(unittest.TestCase):
         mock_resp = Mock()
         mock_trace = Mock()
         mock_environ = {}
-        self.m_gbl.start_trace.return_value = mock_trace
+        self.m_gbl.propagate_and_start_trace.return_value = mock_trace
 
         mw = HoneyWSGIMiddleware(mock_app)
         mw({}, mock_resp)
-        self.m_gbl.start_trace.assert_called_once()
+        self.m_gbl.propagate_and_start_trace.assert_called_once()
 
         mock_app.assert_called_once_with(mock_environ, ANY)
 

--- a/beeline/middleware/werkzeug/__init__.py
+++ b/beeline/middleware/werkzeug/__init__.py
@@ -1,33 +1,6 @@
 import beeline
 from beeline.propagation import Request
-
-
-class WerkzeugRequest(Request):
-    def __init__(self, environ):
-        self._environ = environ
-
-    def header(self, key):
-        # FIXME: Is this .upper strictly necessary? Does environ already do it for us?
-        lookup_key = key.upper().replace('-', '_')
-        return self._environ.get(lookup_key)
-
-    def method(self):
-        return self._environ.get('REQUEST_METHOD')
-
-    def scheme(self):
-        return self._environ.get('wsgi.url_scheme')
-
-    def host(self):
-        return self._environ.get('HTTP_HOST')
-
-    def path(self):
-        return self._environ.get('PATH_INFO')
-
-    def query(self):
-        return self._environ.get('QUERY_STRING')
-
-    def middleware_request(self):
-        return self._environ
+from beeline.middleware.wsgi import WSGIRequest
 
 
 class HoneyWSGIMiddleware(object):
@@ -36,10 +9,9 @@ class HoneyWSGIMiddleware(object):
         self.app = app
 
     def __call__(self, environ, start_response):
-        wr = WerkzeugRequest(environ)
+        wr = WSGIRequest("werkzeug", environ)
 
-        request_context = self.get_context_from_environ(environ)
-        root_span = beeline.propagate_and_start_trace(request_context, wr)
+        root_span = beeline.propagate_and_start_trace(wr.request_context(), wr)
 
         def _start_response(status, headers, *args):
             beeline.add_context_field("response.status_code", status)
@@ -48,23 +20,3 @@ class HoneyWSGIMiddleware(object):
             return start_response(status, headers, *args)
 
         return self.app(environ, _start_response)
-
-    def get_context_from_environ(self, environ):
-        request_method = environ.get('REQUEST_METHOD')
-        if request_method:
-            trace_name = "werkzeug_http_%s" % request_method.lower()
-        else:
-            trace_name = "werkzeug_http"
-
-        return {
-            "name": trace_name,
-            "type": "http_server",
-            "request.host": environ.get('HTTP_HOST'),
-            "request.method": request_method,
-            "request.path": environ.get('PATH_INFO'),
-            "request.remote_addr": environ.get('REMOTE_ADDR'),
-            "request.content_length": environ.get('CONTENT_LENGTH', 0),
-            "request.user_agent": environ.get('HTTP_USER_AGENT'),
-            "request.scheme": environ.get('wsgi.url_scheme'),
-            "request.query": environ.get('QUERY_STRING')
-        }

--- a/beeline/middleware/werkzeug/__init__.py
+++ b/beeline/middleware/werkzeug/__init__.py
@@ -1,4 +1,15 @@
 import beeline
+from beeline.propagation import PropagationHeaders
+
+
+class WerkzeugHeaders(PropagationHeaders):
+    def __init__(self, environ):
+        self._environ = environ
+
+    def get(self, key):
+        # FIXME: Is this .upper strictly necessary? Does environ already do it for us?
+        lookup_key = key.upper().replace('-', '_')
+        return self._environ.get(lookup_key)
 
 
 class HoneyWSGIMiddleware(object):
@@ -7,13 +18,14 @@ class HoneyWSGIMiddleware(object):
         self.app = app
 
     def __call__(self, environ, start_response):
+        headers = WerkzeugHeaders(environ)
 
-        trace = beeline.start_trace(
-            context=self.get_context_from_environ(environ))
+        request_context = self.get_context_from_environ(environ)
+        root_span = beeline.propagate_and_start_trace(request_context, headers)
 
         def _start_response(status, headers, *args):
             beeline.add_context_field("response.status_code", status)
-            beeline.finish_trace(trace)
+            beeline.finish_trace(root_span)
 
             return start_response(status, headers, *args)
 

--- a/beeline/middleware/werkzeug/test_werkzeug.py
+++ b/beeline/middleware/werkzeug/test_werkzeug.py
@@ -15,11 +15,11 @@ class SimpleWSGITest(unittest.TestCase):
         mock_resp = Mock()
         mock_trace = Mock()
         mock_environ = {}
-        self.m_gbl.start_trace.return_value = mock_trace
+        self.m_gbl.propagate_and_start_trace.return_value = mock_trace
 
         mw = HoneyWSGIMiddleware(mock_app)
         mw({}, mock_resp)
-        self.m_gbl.start_trace.assert_called_once()
+        self.m_gbl.propagate_and_start_trace.assert_called_once()
 
         mock_app.assert_called_once_with(mock_environ, ANY)
 

--- a/beeline/middleware/wsgi.py
+++ b/beeline/middleware/wsgi.py
@@ -1,0 +1,50 @@
+from beeline.propagation import Request
+
+
+class WSGIRequest(Request):
+    def __init__(self, mwname, environ):
+        self._mwname = mwname
+        self._environ = environ
+
+    def header(self, key):
+        # FIXME: Is this .upper strictly necessary? Does environ already do it for us?
+        lookup_key = "HTTP_" + key.upper().replace('-', '_')
+        return self._environ.get(lookup_key)
+
+    def method(self):
+        return self._environ.get('REQUEST_METHOD')
+
+    def scheme(self):
+        return self._environ.get('wsgi.url_scheme')
+
+    def host(self):
+        return self._environ.get('HTTP_HOST')
+
+    def path(self):
+        return self._environ.get('PATH_INFO')
+
+    def query(self):
+        return self._environ.get('QUERY_STRING')
+
+    def middleware_request(self):
+        return self._environ
+
+    def request_context(self):
+        request_method = self._environ.get('REQUEST_METHOD')
+        if request_method:
+            trace_name = "%s_http_%s" % (self._mwname, request_method.lower())
+        else:
+            trace_name = "%s_http" % self._mwname
+
+        return {
+            "name": trace_name,
+            "type": "http_server",
+            "request.host": self._environ.get('HTTP_HOST'),
+            "request.method": request_method,
+            "request.path": self._environ.get('PATH_INFO'),
+            "request.remote_addr": self._environ.get('REMOTE_ADDR'),
+            "request.content_length": self._environ.get('CONTENT_LENGTH', 0),
+            "request.user_agent": self._environ.get('HTTP_USER_AGENT'),
+            "request.scheme": self._environ.get('wsgi.url_scheme'),
+            "request.query": self._environ.get('QUERY_STRING')
+        }

--- a/beeline/patch/requests.py
+++ b/beeline/patch/requests.py
@@ -9,7 +9,7 @@ def request(_request, instance, args, kwargs):
     span = beeline.start_span(context={"meta.type": "http_client"})
 
     b = beeline.get_beeline()
-    if b and b.http_trace_propagation_hook != None:
+    if b and b.http_trace_propagation_hook is not None:
         new_headers = beeline.http_trace_propagation_hook()
         if new_headers:
             b.log(

--- a/beeline/patch/requests.py
+++ b/beeline/patch/requests.py
@@ -9,11 +9,12 @@ def request(_request, instance, args, kwargs):
     span = beeline.start_span(context={"meta.type": "http_client"})
 
     b = beeline.get_beeline()
-    if b:
-        context = b.tracer_impl.marshal_trace_context()
-        if context:
-            b.log("requests lib - adding trace context to outbound request: %s", context)
-            instance.headers['X-Honeycomb-Trace'] = context
+    if b and b.http_trace_propagation_hook != None:
+        new_headers = beeline.http_trace_propagation_hook()
+        if new_headers:
+            b.log(
+                "requests lib - adding trace context to outbound request: %s", new_headers)
+            instance.headers.update(new_headers)
         else:
             b.log("requests lib - no trace context found")
 

--- a/beeline/patch/test_requests.py
+++ b/beeline/patch/test_requests.py
@@ -14,7 +14,11 @@ class TestRequestsPatch(unittest.TestCase):
 
             trace_context = "1;trace_id=foo,parent_id=bar,context=base64value=="
 
-            bl.tracer_impl.marshal_trace_context.return_value = trace_context
+            # FIXME: Not sure that this is a great test, although it matches the previous
+            # test.
+            bl.tracer_impl.http_trace_propagation_hook.return_value = {
+                'X-Honeycomb-Trace': trace_context
+            }
 
             # this is the class instance (Session object) that is passed to our request function
             # by wrapt

--- a/beeline/patch/test_requests.py
+++ b/beeline/patch/test_requests.py
@@ -14,8 +14,6 @@ class TestRequestsPatch(unittest.TestCase):
 
             trace_context = "1;trace_id=foo,parent_id=bar,context=base64value=="
 
-            # FIXME: Not sure that this is a great test, although it matches the previous
-            # test.
             bl.tracer_impl.http_trace_propagation_hook.return_value = {
                 'X-Honeycomb-Trace': trace_context
             }

--- a/beeline/patch/test_urllib.py
+++ b/beeline/patch/test_urllib.py
@@ -17,8 +17,6 @@ class TestUrllibPatch(unittest.TestCase):
 
             trace_context = "1;trace_id=foo,parent_id=bar,context=base64value=="
 
-            # FIXME: Not sure that this is a great test, although it matches the previous
-            # test.
             bl.tracer_impl.http_trace_propagation_hook.return_value = {
                 'X-Honeycomb-Trace': trace_context
             }

--- a/beeline/patch/test_urllib.py
+++ b/beeline/patch/test_urllib.py
@@ -17,7 +17,11 @@ class TestUrllibPatch(unittest.TestCase):
 
             trace_context = "1;trace_id=foo,parent_id=bar,context=base64value=="
 
-            bl.tracer_impl.marshal_trace_context.return_value = trace_context
+            # FIXME: Not sure that this is a great test, although it matches the previous
+            # test.
+            bl.tracer_impl.http_trace_propagation_hook.return_value = {
+                'X-Honeycomb-Trace': trace_context
+            }
             # this is our request call that's being wrapped
             m_urlopen = Mock()
             m_urlopen.return_value = Mock(

--- a/beeline/patch/test_urllib.py
+++ b/beeline/patch/test_urllib.py
@@ -24,17 +24,16 @@ class TestUrllibPatch(unittest.TestCase):
             m_urlopen = Mock()
             m_urlopen.return_value = Mock(
                 headers={'content-type': 'application/json', 'content-length': 23}, status_code=500)
-            args = ['https://example.com']
+            args = ('https://example.com',)
             kwargs = {}
             ret = _urllibopen(m_urlopen, None, args, kwargs)
 
             # ensure our arg gets modified and header set before the real function is called
-            self.assertEqual(type(args[0]), urllib.request.Request)
             self.assertEqual(
-                args[0].full_url, 'https://example.com')  # pylint: disable=no-member
-            self.assertEqual(args[0].headers['X-Honeycomb-Trace'],   # pylint: disable=no-member
-                             trace_context)
-            m_urlopen.assert_called_once_with(*args, **kwargs)
+                type(m_urlopen.call_args.args[0]), urllib.request.Request)
+            self.assertEqual(
+                m_urlopen.call_args.args[0].headers['X-Honeycomb-Trace'], trace_context)
+            m_urlopen.asset_called_once()
             m_urlopen.reset_mock()
 
             # ensure we return a response

--- a/beeline/patch/urllib.py
+++ b/beeline/patch/urllib.py
@@ -14,7 +14,7 @@ def _urllibopen(_urlopen, instance, args, kwargs):
     span = beeline.start_span(context={"meta.type": "http_client"})
 
     b = beeline.get_beeline()
-    if b and b.http_trace_propagation_hook != None:
+    if b and b.http_trace_propagation_hook is not None:
         new_headers = beeline.http_trace_propagation_hook()
         if new_headers:
             # Merge the new headers into the existing headers for the outbound request

--- a/beeline/patch/urllib.py
+++ b/beeline/patch/urllib.py
@@ -1,5 +1,6 @@
 from wrapt import wrap_function_wrapper
 import beeline
+import beeline.propagation
 import urllib.request
 
 
@@ -13,13 +14,14 @@ def _urllibopen(_urlopen, instance, args, kwargs):
     span = beeline.start_span(context={"meta.type": "http_client"})
 
     b = beeline.get_beeline()
-    if b:
-        context = b.tracer_impl.marshal_trace_context()
-        if context:
-            b.log("urllib lib - adding trace context to outbound request: %s", context)
-            args[0].headers['X-Honeycomb-Trace'] = context
-        else:
-            b.log("urllib lib - no trace context found")
+    if b and b.propagation_hook != None:
+        new_headers = beeline.http_trace_propagation_hook()
+        if new_headers:
+            # Merge the new headers into the existing headers for the outbound request
+            b.log(
+                "urllib lib - adding trace context to outbound request: %s", new_headers)
+            print(new_headers)
+            args[0].headers.update(new_headers)
 
     try:
         resp = None

--- a/beeline/patch/urllib.py
+++ b/beeline/patch/urllib.py
@@ -9,7 +9,7 @@ def _urllibopen(_urlopen, instance, args, kwargs):
     # It's easier to process the info contained in the request and modify it
     # by converting the URL string into a Request
     if type(args[0]) != urllib.request.Request:
-        args[0] = urllib.request.Request(args[0])
+        args = (urllib.request.Request(args[0]),) + args[1:]
 
     span = beeline.start_span(context={"meta.type": "http_client"})
 

--- a/beeline/patch/urllib.py
+++ b/beeline/patch/urllib.py
@@ -14,13 +14,12 @@ def _urllibopen(_urlopen, instance, args, kwargs):
     span = beeline.start_span(context={"meta.type": "http_client"})
 
     b = beeline.get_beeline()
-    if b and b.propagation_hook != None:
+    if b and b.http_trace_propagation_hook != None:
         new_headers = beeline.http_trace_propagation_hook()
         if new_headers:
             # Merge the new headers into the existing headers for the outbound request
             b.log(
                 "urllib lib - adding trace context to outbound request: %s", new_headers)
-            print(new_headers)
             args[0].headers.update(new_headers)
 
     try:

--- a/beeline/patch/urllib.py
+++ b/beeline/patch/urllib.py
@@ -9,7 +9,7 @@ def _urllibopen(_urlopen, instance, args, kwargs):
     # It's easier to process the info contained in the request and modify it
     # by converting the URL string into a Request
     if type(args[0]) != urllib.request.Request:
-        args = (urllib.request.Request(args[0]),) + args[1:]
+        args = (urllib.request.Request(args[0]),) + tuple(args[1:])
 
     span = beeline.start_span(context={"meta.type": "http_client"})
 

--- a/beeline/propagation/__init__.py
+++ b/beeline/propagation/__init__.py
@@ -1,0 +1,101 @@
+import abc
+import beeline
+import base64
+import json
+
+
+class PropagationContext(object):
+    def __init__(self, trace_id, parent_id, trace_fields):
+        # FIXME: Better name for context
+        self.trace_id = trace_id
+        self.parent_id = parent_id
+        self.trace_fields = trace_fields
+
+    def mergeContext(self, context):
+        """
+        Given a context, merge the trace_fields into the context. If a field is in both,
+        always use the field from the incoming context. Return the new context.
+        """
+        return self.trace_fields.copy().update(context)
+
+
+class PropagationHeaders(object):
+    @abc.abstractmethod
+    def Get(self, key):
+        """
+        Get the value associated with the specified key, transformed as necessary for the
+        transport and middleware.
+        """
+        return
+
+
+def honeycomb_http_trace_parser_hook(headers):
+    '''
+    Retrieves the honeycomb trace context out of the headers.
+    headers must implement the beeline.propagation.Headers abstract base class
+    '''
+    trace_context = headers.Get('X-Honeycomb-Trace')
+    if trace_context:
+        try:
+            trace_id, parent_id, context = honeycomb_unmarshal_trace_header(
+                trace_context)
+            return PropagationContext(trace_id, parent_id, context)
+        except Exception as e:
+            beeline.internal.log(
+                'error attempting to extract trace context: %s', beeline.internal.stringify_exception(e))
+    return None
+
+
+def honeycomb_http_trace_propagation_hook(propagation_context):
+    '''
+    Given a propagation context, returns a dictionary of key value pairs that should be
+    added to outbound requests (usually HTTP headers)
+    '''
+    print("honeycomb_http_trace_propagation_hook")
+    return {"X-Honeycomb-Trace": honeycomb_marshal_trace_context(propagation_context)}
+
+
+def honeycomb_marshal_trace_context(propagation_context):
+    '''
+    Given a propagation context, returns the contents of a trace header to be
+    injected by middleware.
+    '''
+    # FIXME: Since ALL trace fields are in propagation_context, we may want to strip
+    # some automatically added trace fields that we DON'T want to propagate - e.g. request.*
+    version = 1
+    trace_fields = base64.b64encode(json.dumps(
+        propagation_context.trace_fields).encode()).decode()
+    trace_context = "{};trace_id={},parent_id={},context={}".format(
+        version, propagation_context.trace_id, propagation_context.parent_id, trace_fields
+    )
+
+    return trace_context
+
+
+def honeycomb_unmarshal_trace_context(trace_header):
+    # the first value is the trace payload version
+    # at this time there is only one version, but we should warn
+    # if another version comes through
+    version, data = trace_header.split(';', 1)
+    if version != "1":
+        log('warning: trace_header version %s is unsupported', version)
+        return None, None, None
+
+    kv_pairs = data.split(',')
+
+    trace_id, parent_id, context = None, None, None
+    # Some beelines send "dataset" but we do not handle that yet
+    for pair in kv_pairs:
+        k, v = pair.split('=', 1)
+        if k == 'trace_id':
+            trace_id = v
+        elif k == 'parent_id':
+            parent_id = v
+        elif k == 'context':
+            context = json.loads(base64.b64decode(v.encode()).decode())
+
+    # context should be a dict
+    if context is None:
+        context = {}
+
+    return trace_id, parent_id, context

--- a/beeline/propagation/__init__.py
+++ b/beeline/propagation/__init__.py
@@ -1,4 +1,4 @@
-import abc
+from abc import ABC, abstractmethod
 import beeline
 
 
@@ -10,11 +10,53 @@ class PropagationContext(object):
         self.trace_fields = trace_fields
 
 
-class PropagationHeaders(object):
-    @abc.abstractmethod
-    def Get(self, key):
+class Request(ABC):
+    @abstractmethod
+    def header(self, key):
         """
         Get the value associated with the specified key, transformed as necessary for the
         transport and middleware.
         """
-        return
+        pass
+
+    @abstractmethod
+    def method(self):
+        """
+        For HTTP requests, the HTTP method (GET, PUT, etc.) of the request.
+        """
+        pass
+
+    @abstractmethod
+    def scheme(self):
+        """
+        For HTTP requests, the scheme (http, https, etc.)
+        """
+        pass
+
+    @abstractmethod
+    def host(self):
+        """
+        For HTTP requests, the host part of the URL (e.g. www.honeycomb.io, api.honeycomb.io:80)
+        """
+        pass
+
+    @abstractmethod
+    def path(self):
+        """
+        For HTTP requests, the path part of the URL (e.g. /1/event/)
+        """
+        pass
+
+    @abstractmethod
+    def query(self):
+        """
+        For HTTP requests, the query part of the URL (e.g. key1=value1&key2=value2)
+        """
+        pass
+
+    @abstractmethod
+    def middleware_request(self):
+        """
+        The middleware-specific source of request data (for middleware-specific custom hooks)
+        """
+        pass

--- a/beeline/propagation/__init__.py
+++ b/beeline/propagation/__init__.py
@@ -1,17 +1,33 @@
+import six
 from abc import ABCMeta, abstractmethod
 import beeline
 
 
 class PropagationContext(object):
+    '''
+    PropagationContext represents information that can either be read from, or
+    propagated via standard trace propagation headers such as X-Honeycomb-Trace
+    and W3C headers. http_trace_parser_hooks generate this from requests, and
+    http_trace_propagation_hooks use this to generate a set of headers for
+    outbound HTTP requests.
+    '''
+
     def __init__(self, trace_id, parent_id, trace_fields={}):
-        # FIXME: Better name for context
         self.trace_id = trace_id
         self.parent_id = parent_id
         self.trace_fields = trace_fields
 
 
+@six.add_metaclass(ABCMeta)
 class Request(object):
-    __metaclass__ = ABCMeta
+    '''
+    beeline.propagation.Request is an abstract class that defines the interface that should
+    be used by middleware to pass request information into http_trace_parser_hooks. It should
+    at a minimum contain the equivalent of HTTP headers, and optionally include other HTTP
+    information such as method, schema, host, path, and query. The `middleware_request` method
+    returns a middleware-specific request object or equivalent that can be used by custom hooks
+    to extract additional information to be added to the trace or propagated.
+    '''
 
     @abstractmethod
     def header(self, key):
@@ -62,3 +78,43 @@ class Request(object):
         The middleware-specific source of request data (for middleware-specific custom hooks)
         """
         pass
+
+
+class DictRequest(Request):
+    '''
+    Basic dictionary request that just takes in a dictionary of headers, and a dictionary
+    of request properties. Primarily for testing.
+    '''
+
+    def __init__(self, headers, props={}):
+        self._headers = headers
+        self._props = props
+        self._keymap = {k.lower(): k for k in self._headers.keys()}
+
+    def header(self, key):
+        lookup_key = key.lower()
+        if lookup_key not in self._keymap:
+            return None
+        lookup_key = self._keymap[lookup_key]
+        return self._headers[lookup_key]
+
+    def method(self):
+        return self._props['method']
+
+    def scheme(self):
+        return self._props['scheme']
+
+    def host(self):
+        return self._props['host']
+
+    def path(self):
+        return self._props['path']
+
+    def query(self):
+        return self._props['query']
+
+    def middleware_request(self):
+        return {
+            'headers': self._headers,
+            'props': self._props
+        }

--- a/beeline/propagation/__init__.py
+++ b/beeline/propagation/__init__.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 import beeline
 
 
@@ -10,7 +10,9 @@ class PropagationContext(object):
         self.trace_fields = trace_fields
 
 
-class Request(ABC):
+class Request(object):
+    __metaclass__ = ABCMeta
+
     @abstractmethod
     def header(self, key):
         """

--- a/beeline/propagation/__init__.py
+++ b/beeline/propagation/__init__.py
@@ -1,22 +1,13 @@
 import abc
 import beeline
-import base64
-import json
 
 
 class PropagationContext(object):
-    def __init__(self, trace_id, parent_id, trace_fields):
+    def __init__(self, trace_id, parent_id, trace_fields={}):
         # FIXME: Better name for context
         self.trace_id = trace_id
         self.parent_id = parent_id
         self.trace_fields = trace_fields
-
-    def mergeContext(self, context):
-        """
-        Given a context, merge the trace_fields into the context. If a field is in both,
-        always use the field from the incoming context. Return the new context.
-        """
-        return self.trace_fields.copy().update(context)
 
 
 class PropagationHeaders(object):
@@ -27,75 +18,3 @@ class PropagationHeaders(object):
         transport and middleware.
         """
         return
-
-
-def honeycomb_http_trace_parser_hook(headers):
-    '''
-    Retrieves the honeycomb trace context out of the headers.
-    headers must implement the beeline.propagation.Headers abstract base class
-    '''
-    trace_context = headers.Get('X-Honeycomb-Trace')
-    if trace_context:
-        try:
-            trace_id, parent_id, context = honeycomb_unmarshal_trace_header(
-                trace_context)
-            return PropagationContext(trace_id, parent_id, context)
-        except Exception as e:
-            beeline.internal.log(
-                'error attempting to extract trace context: %s', beeline.internal.stringify_exception(e))
-    return None
-
-
-def honeycomb_http_trace_propagation_hook(propagation_context):
-    '''
-    Given a propagation context, returns a dictionary of key value pairs that should be
-    added to outbound requests (usually HTTP headers)
-    '''
-    print("honeycomb_http_trace_propagation_hook")
-    return {"X-Honeycomb-Trace": honeycomb_marshal_trace_context(propagation_context)}
-
-
-def honeycomb_marshal_trace_context(propagation_context):
-    '''
-    Given a propagation context, returns the contents of a trace header to be
-    injected by middleware.
-    '''
-    # FIXME: Since ALL trace fields are in propagation_context, we may want to strip
-    # some automatically added trace fields that we DON'T want to propagate - e.g. request.*
-    version = 1
-    trace_fields = base64.b64encode(json.dumps(
-        propagation_context.trace_fields).encode()).decode()
-    trace_context = "{};trace_id={},parent_id={},context={}".format(
-        version, propagation_context.trace_id, propagation_context.parent_id, trace_fields
-    )
-
-    return trace_context
-
-
-def honeycomb_unmarshal_trace_context(trace_header):
-    # the first value is the trace payload version
-    # at this time there is only one version, but we should warn
-    # if another version comes through
-    version, data = trace_header.split(';', 1)
-    if version != "1":
-        log('warning: trace_header version %s is unsupported', version)
-        return None, None, None
-
-    kv_pairs = data.split(',')
-
-    trace_id, parent_id, context = None, None, None
-    # Some beelines send "dataset" but we do not handle that yet
-    for pair in kv_pairs:
-        k, v = pair.split('=', 1)
-        if k == 'trace_id':
-            trace_id = v
-        elif k == 'parent_id':
-            parent_id = v
-        elif k == 'context':
-            context = json.loads(base64.b64decode(v.encode()).decode())
-
-    # context should be a dict
-    if context is None:
-        context = {}
-
-    return trace_id, parent_id, context

--- a/beeline/propagation/honeycomb.py
+++ b/beeline/propagation/honeycomb.py
@@ -26,6 +26,9 @@ def http_trace_propagation_hook(propagation_context):
     Given a propagation context, returns a dictionary of key value pairs that should be
     added to outbound requests (usually HTTP headers)
     '''
+    if not propagation_context:
+        return None
+
     return {"X-Honeycomb-Trace": marshal_propagation_context(propagation_context)}
 
 
@@ -34,6 +37,9 @@ def marshal_propagation_context(propagation_context):
     Given a propagation context, returns the contents of a trace header to be
     injected by middleware.
     '''
+    if not propagation_context:
+        return None
+
     # FIXME: Since ALL trace fields are in propagation_context, we may want to strip
     # some automatically added trace fields that we DON'T want to propagate - e.g. request.*
     version = 1

--- a/beeline/propagation/honeycomb.py
+++ b/beeline/propagation/honeycomb.py
@@ -1,0 +1,74 @@
+
+import base64
+import json
+
+
+def http_trace_parser_hook(headers):
+    '''
+    Retrieves the honeycomb trace context out of the headers.
+    headers must implement the beeline.propagation.Headers abstract base class
+    '''
+    trace_header = headers.Get('X-Honeycomb-Trace')
+    if trace_header:
+        try:
+            trace_id, parent_id, context = unmarshal_propagation_context(
+                trace_header)
+            return PropagationContext(trace_id, parent_id, context)
+        except Exception as e:
+            beeline.internal.log(
+                'error attempting to extract trace context: %s', beeline.internal.stringify_exception(e))
+    return None
+
+
+def http_trace_propagation_hook(propagation_context):
+    '''
+    Given a propagation context, returns a dictionary of key value pairs that should be
+    added to outbound requests (usually HTTP headers)
+    '''
+    return {"X-Honeycomb-Trace": marshal_propagation_context(propagation_context)}
+
+
+def marshal_propagation_context(propagation_context):
+    '''
+    Given a propagation context, returns the contents of a trace header to be
+    injected by middleware.
+    '''
+    # FIXME: Since ALL trace fields are in propagation_context, we may want to strip
+    # some automatically added trace fields that we DON'T want to propagate - e.g. request.*
+    version = 1
+    trace_fields = base64.b64encode(json.dumps(
+        propagation_context.trace_fields).encode()).decode()
+    trace_header = "{};trace_id={},parent_id={},context={}".format(
+        version, propagation_context.trace_id, propagation_context.parent_id, trace_fields
+    )
+
+    return trace_header
+
+
+def unmarshal_propagation_context(trace_header):
+    # the first value is the trace payload version
+    # at this time there is only one version, but we should warn
+    # if another version comes through
+    version, data = trace_header.split(';', 1)
+    if version != "1":
+        log('warning: trace_header version %s is unsupported', version)
+        return None, None, None
+
+    kv_pairs = data.split(',')
+
+    trace_id, parent_id, context = None, None, None
+    # Some beelines send "dataset" but we do not handle that yet
+    for pair in kv_pairs:
+        k, v = pair.split('=', 1)
+        if k == 'trace_id':
+            trace_id = v
+        elif k == 'parent_id':
+            parent_id = v
+        elif k == 'context':
+            context = json.loads(base64.b64decode(v.encode()).decode())
+
+    # context should be a dict
+    if context is None:
+        context = {}
+
+    return trace_id, parent_id, context

--- a/beeline/propagation/honeycomb.py
+++ b/beeline/propagation/honeycomb.py
@@ -6,7 +6,7 @@ import json
 
 def http_trace_parser_hook(request):
     '''
-    Retrieves the honeycomb trace context out of the request.
+    Retrieves the honeycomb propagation context out of the request.
     request must implement the beeline.propagation.Request abstract base class
     '''
     trace_header = request.header('X-Honeycomb-Trace')
@@ -47,6 +47,10 @@ def marshal_propagation_context(propagation_context):
 
 
 def unmarshal_propagation_context(trace_header):
+    '''
+    Given the body of the `X-Honeycomb-Trace` header, returns the trace_id,
+    parent_id, and "context".
+    '''
     # the first value is the trace payload version
     # at this time there is only one version, but we should warn
     # if another version comes through

--- a/beeline/propagation/honeycomb.py
+++ b/beeline/propagation/honeycomb.py
@@ -1,4 +1,5 @@
-
+import beeline
+from beeline.propagation import PropagationContext
 import base64
 import json
 
@@ -51,7 +52,8 @@ def unmarshal_propagation_context(trace_header):
     # if another version comes through
     version, data = trace_header.split(';', 1)
     if version != "1":
-        log('warning: trace_header version %s is unsupported', version)
+        beeline.internal.log(
+            'warning: trace_header version %s is unsupported', version)
         return None, None, None
 
     kv_pairs = data.split(',')

--- a/beeline/propagation/honeycomb.py
+++ b/beeline/propagation/honeycomb.py
@@ -3,12 +3,12 @@ import base64
 import json
 
 
-def http_trace_parser_hook(headers):
+def http_trace_parser_hook(request):
     '''
-    Retrieves the honeycomb trace context out of the headers.
-    headers must implement the beeline.propagation.Headers abstract base class
+    Retrieves the honeycomb trace context out of the request.
+    request must implement the beeline.propagation.Request abstract base class
     '''
-    trace_header = headers.Get('X-Honeycomb-Trace')
+    trace_header = request.header('X-Honeycomb-Trace')
     if trace_header:
         try:
             trace_id, parent_id, context = unmarshal_propagation_context(

--- a/beeline/propagation/test_honeycomb.py
+++ b/beeline/propagation/test_honeycomb.py
@@ -1,0 +1,48 @@
+import unittest
+from beeline.propagation import DictRequest, PropagationContext
+import beeline.propagation.honeycomb
+
+header_value = '1;trace_id=bloop,parent_id=scoop,context=e30K'
+
+
+class TestMarshalUnmarshal(unittest.TestCase):
+    def test_roundtrip(self):
+        '''Verify that we can successfully roundtrip (marshal and unmarshal)'''
+        trace_id = "bloop"
+        parent_id = "scoop"
+        trace_fields = {"key": "value"}
+        pc = PropagationContext(trace_id, parent_id, trace_fields)
+        header = beeline.propagation.honeycomb.marshal_propagation_context(pc)
+        new_trace_id, new_parent_id, new_trace_fields = beeline.propagation.honeycomb.unmarshal_propagation_context(
+            header)
+        self.assertEquals(trace_id, new_trace_id)
+        self.assertEquals(parent_id, new_parent_id)
+        self.assertEquals(trace_fields, new_trace_fields)
+
+
+class TestHoneycombHTTPTraceParserHook(unittest.TestCase):
+    def test_has_header(self):
+        '''Test that the hook properly parses honeycomb trace headers'''
+        headers = beeline.propagation.DictRequest({
+            # case shouldn't matter
+            'X-HoNEyComb-TrACE': header_value,
+        })
+        pc = beeline.propagation.honeycomb.http_trace_parser_hook(headers)
+        self.assertEquals(pc.trace_id, "bloop")
+        self.assertEquals(pc.parent_id, "scoop")
+        # FIXME: We should have a legitimate header with trace_field and dataset_id set
+
+    def test_no_header(self):
+        headers = beeline.propagation.DictRequest({})
+        pc = beeline.propagation.honeycomb.http_trace_parser_hook(headers)
+        self.assertIsNone(pc)
+
+
+class TestHoneycombHTTPTracePropagationHook(unittest.TestCase):
+    def test_has_header(self):
+        '''Test that the hook properly parses honeycomb trace headers'''
+        pass
+
+    def test_no_header(self):
+        # pc = beeline.propagation.honeycomb_http_trace_parser_hook()
+        pass

--- a/beeline/propagation/test_propagation.py
+++ b/beeline/propagation/test_propagation.py
@@ -1,0 +1,17 @@
+import unittest
+import beeline.propagation
+
+
+class TestPropagationContext(unittest.TestCase):
+    def test_merge_context(self):
+        '''Test that we properly merge'''
+
+
+class TestHoneycombHTTPTraceParserHook(unittest.TestCase):
+    def test_has_header(self):
+        '''Test that the hook properly parses honeycomb trace headers'''
+        pass
+
+    def test_no_header(self):
+        # pc = beeline.propagation.honeycomb_http_trace_parser_hook()
+        pass

--- a/beeline/propagation/test_propagation.py
+++ b/beeline/propagation/test_propagation.py
@@ -1,17 +1,40 @@
 import unittest
 import beeline.propagation
 
-
-class TestPropagationContext(unittest.TestCase):
-    def test_merge_context(self):
-        '''Test that we properly merge'''
+header_value = '1;trace_id=bloop,parent_id=scoop,context=e30K'
 
 
-class TestHoneycombHTTPTraceParserHook(unittest.TestCase):
-    def test_has_header(self):
-        '''Test that the hook properly parses honeycomb trace headers'''
-        pass
+class TestDictRequest(unittest.TestCase):
+    def test_headers(self):
+        '''Test that we correctly deal with case sensitivity'''
+        request = beeline.propagation.DictRequest({
+            # case shouldn't matter
+            'MixedCaseHeader': "value",
+            'UPPERCASEHEADER': "value"
+        },
+            {})
+        value = request.header('mixedcaseheader')
+        self.assertEqual(value, "value")
+        value = request.header('upperCaseHeader')
+        self.assertEqual(value, "value")
 
-    def test_no_header(self):
-        # pc = beeline.propagation.honeycomb_http_trace_parser_hook()
-        pass
+    def test_request_props(self):
+        '''Test we correctly return request props'''
+        request = beeline.propagation.DictRequest({
+            # case shouldn't matter
+            'MixedCaseHeader': "value",
+            'UPPERCASEHEADER': "value"
+        },
+            {
+                'method': "GET",
+                'scheme': "http",
+                'host': "api.honeycomb.io",
+                'path': "/1/event",
+                'query': "key=value"
+        })
+
+        self.assertEqual(request.method(), "GET")
+        self.assertEqual(request.scheme(), "http")
+        self.assertEqual(request.host(), "api.honeycomb.io")
+        self.assertEqual(request.path(), "/1/event")
+        self.assertEqual(request.query(), "key=value")

--- a/beeline/test_beeline.py
+++ b/beeline/test_beeline.py
@@ -204,7 +204,7 @@ class TestBeeline(unittest.TestCase):
         if "thread_exception" in closure_dict:
             raise closure_dict["thread_exception"]
 
-    def test_treaded_trace(self):
+    def test_threaded_trace(self):
         _beeline = beeline.Beeline()
 
         with patch('beeline.get_beeline') as m_gbl:

--- a/beeline/trace.py
+++ b/beeline/trace.py
@@ -196,7 +196,7 @@ class Tracer(object):
 
         if propagation_context:
             return self.start_trace(context=context, trace_id=propagation_context.trace_id,
-                                    parent_span_id=propagation_context.span_id)
+                                    parent_span_id=propagation_context.parent_id)
             for k, v in propagation_context.trace_fields:
                 self.add_trace_field(k, v)
         else:

--- a/beeline/trace.py
+++ b/beeline/trace.py
@@ -178,13 +178,13 @@ class Tracer(object):
         self.finish_span(span)
         self._trace = None
 
-    def parse_http_trace_headers(self, headers):
+    def parse_http_trace(self, request):
         if not self.http_trace_parser_hook:
             return None
-        return self.http_trace_parser_hook(headers)
+        return self.http_trace_parser_hook(request)
 
-    def propagate_and_start_trace(self, context, headers):
-        propagation_context = self.parse_http_trace_headers(headers)
+    def propagate_and_start_trace(self, context, request):
+        propagation_context = self.parse_http_trace(request)
         if propagation_context:
             return self.start_trace(context=context, trace_id=propagation_context.trace_id,
                                     parent_span_id=propagation_context.span_id)

--- a/beeline/trace.py
+++ b/beeline/trace.py
@@ -32,14 +32,12 @@ class Trace(object):
         self.rollup_fields = defaultdict(float)
         self.http_trace_parser_hook = beeline.propagation.honeycomb_http_trace_parser_hook
         self.http_trace_propagation_hook = beeline.propagation.honeycomb_http_trace_propagation_hook
-        self.propagation_context = None
 
     def copy(self):
         '''Copy the trace state for use in another thread or context.'''
         result = Trace(self.id)
         result.stack = copy.copy(self.stack)
         result.fields = copy.copy(self.fields)
-        # FIXME: Copy propagation context? What about rollup_fields?
         return result
 
 
@@ -194,6 +192,12 @@ class Tracer(object):
             # Initialize a new trace from scratch
             return self.start_trace(context, trace_id=None, parent_span_id=None)
         pass
+
+    def get_propagation_context(self):
+        return beeline.propagation.PropagationContext(
+            self.get_active_trace_id(),
+            self.get_active_span().id,
+            self._trace.fields)
 
     def get_active_trace_id(self):
         if self._trace:

--- a/beeline/trace.py
+++ b/beeline/trace.py
@@ -189,7 +189,7 @@ class Tracer(object):
         propagation_context = None
         try:
             propagation_context = self.parse_http_trace(request)
-        except:
+        except Exception:
             err = sys.exc_info()[0]
             log('error: http_trace_parser_hook returned exception: %s',
                 sys.exc_info()[0])

--- a/beeline/version.py
+++ b/beeline/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.12.2'  # Update using bump2version
+VERSION = '2.13.0-dev0'  # Update using bump2version

--- a/poetry.lock
+++ b/poetry.lock
@@ -44,18 +44,6 @@ version = ">=1.4.0,<1.5"
 
 [[package]]
 category = "dev"
-description = "A tool that automatically formats Python code to conform to the PEP 8 style guide"
-name = "autopep8"
-optional = false
-python-versions = "*"
-version = "1.5.3"
-
-[package.dependencies]
-pycodestyle = ">=2.6.0"
-toml = "*"
-
-[[package]]
-category = "dev"
 description = "Backport of functools.lru_cache"
 marker = "python_version < \"3.0\""
 name = "backports.functools-lru-cache"
@@ -66,6 +54,15 @@ version = "1.6.1"
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-black-multipy", "pytest-cov"]
+
+[[package]]
+category = "dev"
+description = "Version-bump your software with a single command!"
+marker = "python_version >= \"3.5\""
+name = "bump2version"
+optional = false
+python-versions = ">=3.5"
+version = "1.0.0"
 
 [[package]]
 category = "main"
@@ -120,7 +117,7 @@ marker = "python_version >= \"2.7\" and python_version < \"3.0.0\" or python_ver
 name = "coverage"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "5.1"
+version = "5.2.1"
 
 [package.extras]
 toml = ["toml"]
@@ -148,11 +145,11 @@ marker = "python_version >= \"3.5\""
 name = "django"
 optional = false
 python-versions = ">=3.5"
-version = "2.2.13"
+version = "2.2.15"
 
 [package.dependencies]
 pytz = "*"
-sqlparse = "*"
+sqlparse = ">=0.2.2"
 
 [package.extras]
 argon2 = ["argon2-cffi (>=16.1.0)"]
@@ -273,8 +270,8 @@ description = "A fast and thorough lazy object proxy."
 marker = "python_version < \"3.0\""
 name = "lazy-object-proxy"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.5.0"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "1.5.1"
 
 [[package]]
 category = "main"
@@ -450,6 +447,7 @@ version = "3.3.0"
 [[package]]
 category = "dev"
 description = "Python Library for Tom's Obvious, Minimal Language"
+marker = "python_version >= \"3.5\""
 name = "toml"
 optional = false
 python-versions = "*"
@@ -491,7 +489,7 @@ description = "HTTP library with thread-safe connection pooling, file post, and 
 name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "1.25.9"
+version = "1.25.10"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
@@ -519,7 +517,7 @@ python-versions = "*"
 version = "1.12.1"
 
 [metadata]
-content-hash = "ef232cf7b5a065a3fa0e444d21c7b0d550770766588ca41de66f0f354c265013"
+content-hash = "af0cb6ba14e425d6852f1b11bcdb2aa846a4f01d1bde133305e39052bf2676f9"
 lock-version = "1.0"
 python-versions = ">=2.7"
 
@@ -530,12 +528,13 @@ astroid = [
     {file = "astroid-2.4.2-py3-none-any.whl", hash = "sha256:bc58d83eb610252fd8de6363e39d4f1d0619c894b0ed24603b881c02e64c7386"},
     {file = "astroid-2.4.2.tar.gz", hash = "sha256:2f4078c2a41bf377eea06d71c9d2ba4eb8f6b1af2135bec27bbbb7d8f12bb703"},
 ]
-autopep8 = [
-    {file = "autopep8-1.5.3.tar.gz", hash = "sha256:60fd8c4341bab59963dafd5d2a566e94f547e660b9b396f772afe67d8481dbf0"},
-]
 "backports.functools-lru-cache" = [
     {file = "backports.functools_lru_cache-1.6.1-py2.py3-none-any.whl", hash = "sha256:0bada4c2f8a43d533e4ecb7a12214d9420e66eb206d54bf2d682581ca4b80848"},
     {file = "backports.functools_lru_cache-1.6.1.tar.gz", hash = "sha256:8fde5f188da2d593bd5bc0be98d9abc46c95bb8a9dde93429570192ee6cc2d4a"},
+]
+bump2version = [
+    {file = "bump2version-1.0.0-py2.py3-none-any.whl", hash = "sha256:477f0e18a0d58e50bb3dbc9af7fcda464fd0ebfc7a6151d8888602d7153171a0"},
+    {file = "bump2version-1.0.0.tar.gz", hash = "sha256:cd4f3a231305e405ed8944d8ff35bd742d9bc740ad62f483bd0ca21ce7131984"},
 ]
 certifi = [
     {file = "certifi-2020.6.20-py2.py3-none-any.whl", hash = "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"},
@@ -558,43 +557,46 @@ configparser = [
     {file = "configparser-4.0.2.tar.gz", hash = "sha256:c7d282687a5308319bf3d2e7706e575c635b0a470342641c93bea0ea3b5331df"},
 ]
 coverage = [
-    {file = "coverage-5.1-cp27-cp27m-macosx_10_12_x86_64.whl", hash = "sha256:0cb4be7e784dcdc050fc58ef05b71aa8e89b7e6636b99967fadbdba694cf2b65"},
-    {file = "coverage-5.1-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:c317eaf5ff46a34305b202e73404f55f7389ef834b8dbf4da09b9b9b37f76dd2"},
-    {file = "coverage-5.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b83835506dfc185a319031cf853fa4bb1b3974b1f913f5bb1a0f3d98bdcded04"},
-    {file = "coverage-5.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5f2294dbf7875b991c381e3d5af2bcc3494d836affa52b809c91697449d0eda6"},
-    {file = "coverage-5.1-cp27-cp27m-win32.whl", hash = "sha256:de807ae933cfb7f0c7d9d981a053772452217df2bf38e7e6267c9cbf9545a796"},
-    {file = "coverage-5.1-cp27-cp27m-win_amd64.whl", hash = "sha256:bf9cb9a9fd8891e7efd2d44deb24b86d647394b9705b744ff6f8261e6f29a730"},
-    {file = "coverage-5.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:acf3763ed01af8410fc36afea23707d4ea58ba7e86a8ee915dfb9ceff9ef69d0"},
-    {file = "coverage-5.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:dec5202bfe6f672d4511086e125db035a52b00f1648d6407cc8e526912c0353a"},
-    {file = "coverage-5.1-cp35-cp35m-macosx_10_12_x86_64.whl", hash = "sha256:7a5bdad4edec57b5fb8dae7d3ee58622d626fd3a0be0dfceda162a7035885ecf"},
-    {file = "coverage-5.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1601e480b9b99697a570cea7ef749e88123c04b92d84cedaa01e117436b4a0a9"},
-    {file = "coverage-5.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:dbe8c6ae7534b5b024296464f387d57c13caa942f6d8e6e0346f27e509f0f768"},
-    {file = "coverage-5.1-cp35-cp35m-win32.whl", hash = "sha256:a027ef0492ede1e03a8054e3c37b8def89a1e3c471482e9f046906ba4f2aafd2"},
-    {file = "coverage-5.1-cp35-cp35m-win_amd64.whl", hash = "sha256:0e61d9803d5851849c24f78227939c701ced6704f337cad0a91e0972c51c1ee7"},
-    {file = "coverage-5.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:2d27a3f742c98e5c6b461ee6ef7287400a1956c11421eb574d843d9ec1f772f0"},
-    {file = "coverage-5.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:66460ab1599d3cf894bb6baee8c684788819b71a5dc1e8fa2ecc152e5d752019"},
-    {file = "coverage-5.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5c542d1e62eece33c306d66fe0a5c4f7f7b3c08fecc46ead86d7916684b36d6c"},
-    {file = "coverage-5.1-cp36-cp36m-win32.whl", hash = "sha256:2742c7515b9eb368718cd091bad1a1b44135cc72468c731302b3d641895b83d1"},
-    {file = "coverage-5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:dead2ddede4c7ba6cb3a721870f5141c97dc7d85a079edb4bd8d88c3ad5b20c7"},
-    {file = "coverage-5.1-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:01333e1bd22c59713ba8a79f088b3955946e293114479bbfc2e37d522be03355"},
-    {file = "coverage-5.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e1ea316102ea1e1770724db01998d1603ed921c54a86a2efcb03428d5417e489"},
-    {file = "coverage-5.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:adeb4c5b608574a3d647011af36f7586811a2c1197c861aedb548dd2453b41cd"},
-    {file = "coverage-5.1-cp37-cp37m-win32.whl", hash = "sha256:782caea581a6e9ff75eccda79287daefd1d2631cc09d642b6ee2d6da21fc0a4e"},
-    {file = "coverage-5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:00f1d23f4336efc3b311ed0d807feb45098fc86dee1ca13b3d6768cdab187c8a"},
-    {file = "coverage-5.1-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:402e1744733df483b93abbf209283898e9f0d67470707e3c7516d84f48524f55"},
-    {file = "coverage-5.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:a3f3654d5734a3ece152636aad89f58afc9213c6520062db3978239db122f03c"},
-    {file = "coverage-5.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6402bd2fdedabbdb63a316308142597534ea8e1895f4e7d8bf7476c5e8751fef"},
-    {file = "coverage-5.1-cp38-cp38-win32.whl", hash = "sha256:8fa0cbc7ecad630e5b0f4f35b0f6ad419246b02bc750de7ac66db92667996d24"},
-    {file = "coverage-5.1-cp38-cp38-win_amd64.whl", hash = "sha256:79a3cfd6346ce6c13145731d39db47b7a7b859c0272f02cdb89a3bdcbae233a0"},
-    {file = "coverage-5.1-cp39-cp39-win32.whl", hash = "sha256:a82b92b04a23d3c8a581fc049228bafde988abacba397d57ce95fe95e0338ab4"},
-    {file = "coverage-5.1-cp39-cp39-win_amd64.whl", hash = "sha256:bb28a7245de68bf29f6fb199545d072d1036a1917dca17a1e75bbb919e14ee8e"},
-    {file = "coverage-5.1.tar.gz", hash = "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"},
+    {file = "coverage-5.2.1-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:40f70f81be4d34f8d491e55936904db5c527b0711b2a46513641a5729783c2e4"},
+    {file = "coverage-5.2.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:675192fca634f0df69af3493a48224f211f8db4e84452b08d5fcebb9167adb01"},
+    {file = "coverage-5.2.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:2fcc8b58953d74d199a1a4d633df8146f0ac36c4e720b4a1997e9b6327af43a8"},
+    {file = "coverage-5.2.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:64c4f340338c68c463f1b56e3f2f0423f7b17ba6c3febae80b81f0e093077f59"},
+    {file = "coverage-5.2.1-cp27-cp27m-win32.whl", hash = "sha256:52f185ffd3291196dc1aae506b42e178a592b0b60a8610b108e6ad892cfc1bb3"},
+    {file = "coverage-5.2.1-cp27-cp27m-win_amd64.whl", hash = "sha256:30bc103587e0d3df9e52cd9da1dd915265a22fad0b72afe54daf840c984b564f"},
+    {file = "coverage-5.2.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:9ea749fd447ce7fb1ac71f7616371f04054d969d412d37611716721931e36efd"},
+    {file = "coverage-5.2.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ce7866f29d3025b5b34c2e944e66ebef0d92e4a4f2463f7266daa03a1332a651"},
+    {file = "coverage-5.2.1-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:4869ab1c1ed33953bb2433ce7b894a28d724b7aa76c19b11e2878034a4e4680b"},
+    {file = "coverage-5.2.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:a3ee9c793ffefe2944d3a2bd928a0e436cd0ac2d9e3723152d6fd5398838ce7d"},
+    {file = "coverage-5.2.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:28f42dc5172ebdc32622a2c3f7ead1b836cdbf253569ae5673f499e35db0bac3"},
+    {file = "coverage-5.2.1-cp35-cp35m-win32.whl", hash = "sha256:e26c993bd4b220429d4ec8c1468eca445a4064a61c74ca08da7429af9bc53bb0"},
+    {file = "coverage-5.2.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4186fc95c9febeab5681bc3248553d5ec8c2999b8424d4fc3a39c9cba5796962"},
+    {file = "coverage-5.2.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:b360d8fd88d2bad01cb953d81fd2edd4be539df7bfec41e8753fe9f4456a5082"},
+    {file = "coverage-5.2.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:1adb6be0dcef0cf9434619d3b892772fdb48e793300f9d762e480e043bd8e716"},
+    {file = "coverage-5.2.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:098a703d913be6fbd146a8c50cc76513d726b022d170e5e98dc56d958fd592fb"},
+    {file = "coverage-5.2.1-cp36-cp36m-win32.whl", hash = "sha256:962c44070c281d86398aeb8f64e1bf37816a4dfc6f4c0f114756b14fc575621d"},
+    {file = "coverage-5.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1ed2bdb27b4c9fc87058a1cb751c4df8752002143ed393899edb82b131e0546"},
+    {file = "coverage-5.2.1-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:c890728a93fffd0407d7d37c1e6083ff3f9f211c83b4316fae3778417eab9811"},
+    {file = "coverage-5.2.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:538f2fd5eb64366f37c97fdb3077d665fa946d2b6d95447622292f38407f9258"},
+    {file = "coverage-5.2.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:27ca5a2bc04d68f0776f2cdcb8bbd508bbe430a7bf9c02315cd05fb1d86d0034"},
+    {file = "coverage-5.2.1-cp37-cp37m-win32.whl", hash = "sha256:aab75d99f3f2874733946a7648ce87a50019eb90baef931698f96b76b6769a46"},
+    {file = "coverage-5.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:c2ff24df02a125b7b346c4c9078c8936da06964cc2d276292c357d64378158f8"},
+    {file = "coverage-5.2.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:304fbe451698373dc6653772c72c5d5e883a4aadaf20343592a7abb2e643dae0"},
+    {file = "coverage-5.2.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:c96472b8ca5dc135fb0aa62f79b033f02aa434fb03a8b190600a5ae4102df1fd"},
+    {file = "coverage-5.2.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8505e614c983834239f865da2dd336dcf9d72776b951d5dfa5ac36b987726e1b"},
+    {file = "coverage-5.2.1-cp38-cp38-win32.whl", hash = "sha256:700997b77cfab016533b3e7dbc03b71d33ee4df1d79f2463a318ca0263fc29dd"},
+    {file = "coverage-5.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:46794c815e56f1431c66d81943fa90721bb858375fb36e5903697d5eef88627d"},
+    {file = "coverage-5.2.1-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:16042dc7f8e632e0dcd5206a5095ebd18cb1d005f4c89694f7f8aafd96dd43a3"},
+    {file = "coverage-5.2.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c1bbb628ed5192124889b51204de27c575b3ffc05a5a91307e7640eff1d48da4"},
+    {file = "coverage-5.2.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:4f6428b55d2916a69f8d6453e48a505c07b2245653b0aa9f0dee38785939f5e4"},
+    {file = "coverage-5.2.1-cp39-cp39-win32.whl", hash = "sha256:9e536783a5acee79a9b308be97d3952b662748c4037b6a24cbb339dc7ed8eb89"},
+    {file = "coverage-5.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:b8f58c7db64d8f27078cbf2a4391af6aa4e4767cc08b37555c4ae064b8558d9b"},
+    {file = "coverage-5.2.1.tar.gz", hash = "sha256:a34cb28e0747ea15e82d13e14de606747e9e484fb28d63c999483f5d5188e89b"},
 ]
 django = [
     {file = "Django-1.11.29-py2.py3-none-any.whl", hash = "sha256:014e3392058d94f40569206a24523ce254d55ad2f9f46c6550b0fe2e4f94cf3f"},
     {file = "Django-1.11.29.tar.gz", hash = "sha256:4200aefb6678019a0acf0005cd14cfce3a5e6b9b90d06145fcdd2e474ad4329c"},
-    {file = "Django-2.2.13-py3-none-any.whl", hash = "sha256:e8fe3c2b2212dce6126becab7a693157f1a441a07b62ec994c046c76af5bb66d"},
-    {file = "Django-2.2.13.tar.gz", hash = "sha256:84f370f6acedbe1f3c41e1a02de44ac206efda3355e427139ecb785b5f596d80"},
+    {file = "Django-2.2.15-py3-none-any.whl", hash = "sha256:91f540000227eace0504a24f508de26daa756353aa7376c6972d7920bc339a3a"},
+    {file = "Django-2.2.15.tar.gz", hash = "sha256:3e2f5d172215862abf2bac3138d8a04229d34dbd2d0dab42c6bf33876cc22323"},
 ]
 enum34 = [
     {file = "enum34-1.1.10-py2-none-any.whl", hash = "sha256:a98a201d6de3f2ab3db284e70a33b0f896fbf35f8086594e8c9e74b909058d53"},
@@ -651,24 +653,28 @@ lazy-object-proxy = [
     {file = "lazy_object_proxy-1.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62"},
     {file = "lazy_object_proxy-1.4.3-cp38-cp38-win32.whl", hash = "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd"},
     {file = "lazy_object_proxy-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239"},
-    {file = "lazy-object-proxy-1.5.0.tar.gz", hash = "sha256:a0aed261060cd0372abf08d16399b1224dbb5b400312e6b00f2b23eabe1d4e96"},
-    {file = "lazy_object_proxy-1.5.0-cp27-cp27m-macosx_10_13_x86_64.whl", hash = "sha256:ec6aba217d0c4f71cbe48aea962a382dedcd111f47b55e8b58d4aaca519bd360"},
-    {file = "lazy_object_proxy-1.5.0-cp27-cp27m-win32.whl", hash = "sha256:e9a571e7168076a0d5ecaabd91e9032e86d815cca3a4bf0dafead539ef071aa5"},
-    {file = "lazy_object_proxy-1.5.0-cp27-cp27m-win_amd64.whl", hash = "sha256:e3183fbeb452ec11670c2d9bfd08a57bc87e46856b24d1c335f995239bedd0e1"},
-    {file = "lazy_object_proxy-1.5.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:96f2cdb35bdfda10e075f12892a42cff5179bbda698992b845f36c5e92755d33"},
-    {file = "lazy_object_proxy-1.5.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:51035b175740c44707694c521560b55b66da9d5a7c545cf22582bc02deb61664"},
-    {file = "lazy_object_proxy-1.5.0-cp35-cp35m-win32.whl", hash = "sha256:2d58f0e6395bf41087a383a48b06b42165f3b699f1aa41ba201db84ab77be63d"},
-    {file = "lazy_object_proxy-1.5.0-cp35-cp35m-win_amd64.whl", hash = "sha256:cbf1354292a4f7abb6a0188f74f5e902e4510ebad105be1dbc4809d1ed92f77e"},
-    {file = "lazy_object_proxy-1.5.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:459ef557e669d0046fe2b92eb4822c097c00b5ef9d11df0f9bd7d4267acdfc52"},
-    {file = "lazy_object_proxy-1.5.0-cp36-cp36m-win32.whl", hash = "sha256:dd89f466c930d7cfe84c94b5cbe862867c88b269f23e5aa61d40945e0d746f54"},
-    {file = "lazy_object_proxy-1.5.0-cp36-cp36m-win_amd64.whl", hash = "sha256:4a50513b6be001b9b7be2c435478fe9669249c77c241813907a44cda1fcd03f4"},
-    {file = "lazy_object_proxy-1.5.0-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:159ae2bbb4dc3ba506aeba868d14e56a754c0be402d1f0d7fdb264e0bdf2b095"},
-    {file = "lazy_object_proxy-1.5.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:161a68a427022bf13e249458be2cb8da56b055988c584d372a917c665825ae9a"},
-    {file = "lazy_object_proxy-1.5.0-cp37-cp37m-win32.whl", hash = "sha256:311c9d1840042fc8e2dd80fc80272a7ea73e7646745556153c9cda85a4628b18"},
-    {file = "lazy_object_proxy-1.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:0aef3fa29f7d1194d6f8a99382b1b844e5a14d3bc1ef82c3b1c4fb7e7e2019bc"},
-    {file = "lazy_object_proxy-1.5.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:a6052c4c7d95de2345d9c58fc0fe34fff6c27a8ed8550dafeb18ada84406cc99"},
-    {file = "lazy_object_proxy-1.5.0-cp38-cp38-win32.whl", hash = "sha256:da82b2372f5ded8806eaac95b19af89a7174efdb418d4e7beb0c6ab09cee7d95"},
-    {file = "lazy_object_proxy-1.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:35c3ad7b7f7d5d4a54a80f0ff5a41ab186237d6486843f8dde00c42cfab33905"},
+    {file = "lazy-object-proxy-1.5.1.tar.gz", hash = "sha256:9723364577b79ad9958a68851fe2acb94da6fd25170c595516a8289e6a129043"},
+    {file = "lazy_object_proxy-1.5.1-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:92cedd6e26712505adb1c17fab64651a498cc0102a80ba562ff4a2451088f57a"},
+    {file = "lazy_object_proxy-1.5.1-cp27-cp27m-win32.whl", hash = "sha256:ef355fb3802e0fc5a71dadb65a3c317bfc9bdf567d357f8e0b1900b432ffe486"},
+    {file = "lazy_object_proxy-1.5.1-cp27-cp27m-win_amd64.whl", hash = "sha256:3e8698dc384857413580012f4ca322d89e63ef20fc3d4635a5b606d6d4b61f6a"},
+    {file = "lazy_object_proxy-1.5.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:edbcb4c5efabd93ede05b272296a5a78a67e9b6e82ba7f51a07b8103db06ce01"},
+    {file = "lazy_object_proxy-1.5.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:33da47ba3a581860ddd3d38c950a5fe950ca389f7123edd0d6ab0bc473499fe7"},
+    {file = "lazy_object_proxy-1.5.1-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:c697bd1b333b3e6abdff04ef9f5fb4b1936633d9cc4e28d90606705c9083254c"},
+    {file = "lazy_object_proxy-1.5.1-cp35-cp35m-win32.whl", hash = "sha256:8133b63b05f12751cddd8e3e7f02ba39dc7cfa7d2ba99d80d7436f0ba26d6b75"},
+    {file = "lazy_object_proxy-1.5.1-cp35-cp35m-win_amd64.whl", hash = "sha256:30ef2068f4f94660144515380ef04b93d15add2214eab8be4cd46ebc900d681c"},
+    {file = "lazy_object_proxy-1.5.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:042b54fd71c2092e6d10e5e66fa60f65c5954f8145e809f5d9f394c9b13d32ee"},
+    {file = "lazy_object_proxy-1.5.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:db2df3eff7ed3e6813638686f1bb5934d1a0662d9d3b4196b5164a86be3a1e8f"},
+    {file = "lazy_object_proxy-1.5.1-cp36-cp36m-win32.whl", hash = "sha256:4fdd7113fc5143c72dacf415079eec42fcbe69cc9d3d291b4ca742e3a9455807"},
+    {file = "lazy_object_proxy-1.5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:11f87dc06eb5f376cc6d5f0c19a1b4dca202035622777c4ce8e5b72c87b035d6"},
+    {file = "lazy_object_proxy-1.5.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:22c1935c6f8e3d6ea2e169eb03928adbdb8a2251d2890f8689368d65e70aa176"},
+    {file = "lazy_object_proxy-1.5.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:19ae6f6511a02008ef3554e158c41bb2a8e5c8455935b98d6da076d9f152fd7c"},
+    {file = "lazy_object_proxy-1.5.1-cp37-cp37m-win32.whl", hash = "sha256:8d82e27cbbea6edb8821751806f39f5dcfd7b46a5e23d27b98d6d8c8ec751df8"},
+    {file = "lazy_object_proxy-1.5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:c484020ad26973a14a7cb1e1d2e0bfe97cf6803273ae9bd154e0213cc74bad49"},
+    {file = "lazy_object_proxy-1.5.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:fe2f61fed5817bf8db01d9a72309ed5990c478a077e9585b58740c26774bce39"},
+    {file = "lazy_object_proxy-1.5.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:63b6d9a5077d54db271fcc6772440f7380ec3fa559d0e2497dbfae2f47c2c814"},
+    {file = "lazy_object_proxy-1.5.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:d0f7e14ff3424639d33e6bc449e77e4b345e52c21bbd6f6004a1d219196e2664"},
+    {file = "lazy_object_proxy-1.5.1-cp38-cp38-win32.whl", hash = "sha256:89b8e5780e49753e2b4cd5aab45d3df092ddcbba3de2c4d4492a029588fe1758"},
+    {file = "lazy_object_proxy-1.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:00b78a97a79d0dfefa584d44dd1aba9668d3de7ec82335ba0ff51d53ef107143"},
 ]
 libhoney = [
     {file = "libhoney-1.9.0.tar.gz", hash = "sha256:b70010f9c37fed4e27708a1b16f1dc6de9486dd21c9a986b3764f84b3c944fee"},
@@ -791,8 +797,8 @@ typed-ast = [
 urllib3 = [
     {file = "urllib3-1.22-py2.py3-none-any.whl", hash = "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b"},
     {file = "urllib3-1.22.tar.gz", hash = "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"},
-    {file = "urllib3-1.25.9-py2.py3-none-any.whl", hash = "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"},
-    {file = "urllib3-1.25.9.tar.gz", hash = "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527"},
+    {file = "urllib3-1.25.10-py2.py3-none-any.whl", hash = "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"},
+    {file = "urllib3-1.25.10.tar.gz", hash = "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a"},
 ]
 werkzeug = [
     {file = "Werkzeug-1.0.1-py2.py3-none-any.whl", hash = "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -44,6 +44,18 @@ version = ">=1.4.0,<1.5"
 
 [[package]]
 category = "dev"
+description = "A tool that automatically formats Python code to conform to the PEP 8 style guide"
+name = "autopep8"
+optional = false
+python-versions = "*"
+version = "1.5.3"
+
+[package.dependencies]
+pycodestyle = ">=2.6.0"
+toml = "*"
+
+[[package]]
+category = "dev"
 description = "Backport of functools.lru_cache"
 marker = "python_version < \"3.0\""
 name = "backports.functools-lru-cache"
@@ -54,15 +66,6 @@ version = "1.6.1"
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-black-multipy", "pytest-cov"]
-
-[[package]]
-category = "dev"
-description = "Version-bump your software with a single command!"
-marker = "python_version >= \"3.5\""
-name = "bump2version"
-optional = false
-python-versions = ">=3.5"
-version = "1.0.0"
 
 [[package]]
 category = "main"
@@ -117,7 +120,7 @@ marker = "python_version >= \"2.7\" and python_version < \"3.0.0\" or python_ver
 name = "coverage"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "5.2"
+version = "5.1"
 
 [package.extras]
 toml = ["toml"]
@@ -145,11 +148,11 @@ marker = "python_version >= \"3.5\""
 name = "django"
 optional = false
 python-versions = ">=3.5"
-version = "2.2.14"
+version = "2.2.13"
 
 [package.dependencies]
 pytz = "*"
-sqlparse = ">=0.2.2"
+sqlparse = "*"
 
 [package.extras]
 argon2 = ["argon2-cffi (>=16.1.0)"]
@@ -270,8 +273,8 @@ description = "A fast and thorough lazy object proxy."
 marker = "python_version < \"3.0\""
 name = "lazy-object-proxy"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "1.5.1"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.5.0"
 
 [[package]]
 category = "main"
@@ -447,7 +450,6 @@ version = "3.3.0"
 [[package]]
 category = "dev"
 description = "Python Library for Tom's Obvious, Minimal Language"
-marker = "python_version >= \"3.5\""
 name = "toml"
 optional = false
 python-versions = "*"
@@ -489,7 +491,7 @@ description = "HTTP library with thread-safe connection pooling, file post, and 
 name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "1.25.10"
+version = "1.25.9"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
@@ -517,7 +519,7 @@ python-versions = "*"
 version = "1.12.1"
 
 [metadata]
-content-hash = "af0cb6ba14e425d6852f1b11bcdb2aa846a4f01d1bde133305e39052bf2676f9"
+content-hash = "ef232cf7b5a065a3fa0e444d21c7b0d550770766588ca41de66f0f354c265013"
 lock-version = "1.0"
 python-versions = ">=2.7"
 
@@ -528,13 +530,12 @@ astroid = [
     {file = "astroid-2.4.2-py3-none-any.whl", hash = "sha256:bc58d83eb610252fd8de6363e39d4f1d0619c894b0ed24603b881c02e64c7386"},
     {file = "astroid-2.4.2.tar.gz", hash = "sha256:2f4078c2a41bf377eea06d71c9d2ba4eb8f6b1af2135bec27bbbb7d8f12bb703"},
 ]
+autopep8 = [
+    {file = "autopep8-1.5.3.tar.gz", hash = "sha256:60fd8c4341bab59963dafd5d2a566e94f547e660b9b396f772afe67d8481dbf0"},
+]
 "backports.functools-lru-cache" = [
     {file = "backports.functools_lru_cache-1.6.1-py2.py3-none-any.whl", hash = "sha256:0bada4c2f8a43d533e4ecb7a12214d9420e66eb206d54bf2d682581ca4b80848"},
     {file = "backports.functools_lru_cache-1.6.1.tar.gz", hash = "sha256:8fde5f188da2d593bd5bc0be98d9abc46c95bb8a9dde93429570192ee6cc2d4a"},
-]
-bump2version = [
-    {file = "bump2version-1.0.0-py2.py3-none-any.whl", hash = "sha256:477f0e18a0d58e50bb3dbc9af7fcda464fd0ebfc7a6151d8888602d7153171a0"},
-    {file = "bump2version-1.0.0.tar.gz", hash = "sha256:cd4f3a231305e405ed8944d8ff35bd742d9bc740ad62f483bd0ca21ce7131984"},
 ]
 certifi = [
     {file = "certifi-2020.6.20-py2.py3-none-any.whl", hash = "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"},
@@ -557,46 +558,43 @@ configparser = [
     {file = "configparser-4.0.2.tar.gz", hash = "sha256:c7d282687a5308319bf3d2e7706e575c635b0a470342641c93bea0ea3b5331df"},
 ]
 coverage = [
-    {file = "coverage-5.2-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:d9ad0a988ae20face62520785ec3595a5e64f35a21762a57d115dae0b8fb894a"},
-    {file = "coverage-5.2-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:4bb385a747e6ae8a65290b3df60d6c8a692a5599dc66c9fa3520e667886f2e10"},
-    {file = "coverage-5.2-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:9702e2cb1c6dec01fb8e1a64c015817c0800a6eca287552c47a5ee0ebddccf62"},
-    {file = "coverage-5.2-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:42fa45a29f1059eda4d3c7b509589cc0343cd6bbf083d6118216830cd1a51613"},
-    {file = "coverage-5.2-cp27-cp27m-win32.whl", hash = "sha256:41d88736c42f4a22c494c32cc48a05828236e37c991bd9760f8923415e3169e4"},
-    {file = "coverage-5.2-cp27-cp27m-win_amd64.whl", hash = "sha256:bbb387811f7a18bdc61a2ea3d102be0c7e239b0db9c83be7bfa50f095db5b92a"},
-    {file = "coverage-5.2-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:3740b796015b889e46c260ff18b84683fa2e30f0f75a171fb10d2bf9fb91fc70"},
-    {file = "coverage-5.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ebf2431b2d457ae5217f3a1179533c456f3272ded16f8ed0b32961a6d90e38ee"},
-    {file = "coverage-5.2-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:d54d7ea74cc00482a2410d63bf10aa34ebe1c49ac50779652106c867f9986d6b"},
-    {file = "coverage-5.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:87bdc8135b8ee739840eee19b184804e5d57f518578ffc797f5afa2c3c297913"},
-    {file = "coverage-5.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:ed9a21502e9223f563e071759f769c3d6a2e1ba5328c31e86830368e8d78bc9c"},
-    {file = "coverage-5.2-cp35-cp35m-win32.whl", hash = "sha256:509294f3e76d3f26b35083973fbc952e01e1727656d979b11182f273f08aa80b"},
-    {file = "coverage-5.2-cp35-cp35m-win_amd64.whl", hash = "sha256:ca63dae130a2e788f2b249200f01d7fa240f24da0596501d387a50e57aa7075e"},
-    {file = "coverage-5.2-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:5c74c5b6045969b07c9fb36b665c9cac84d6c174a809fc1b21bdc06c7836d9a0"},
-    {file = "coverage-5.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:c32aa13cc3fe86b0f744dfe35a7f879ee33ac0a560684fef0f3e1580352b818f"},
-    {file = "coverage-5.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1e58fca3d9ec1a423f1b7f2aa34af4f733cbfa9020c8fe39ca451b6071237405"},
-    {file = "coverage-5.2-cp36-cp36m-win32.whl", hash = "sha256:3b2c34690f613525672697910894b60d15800ac7e779fbd0fccf532486c1ba40"},
-    {file = "coverage-5.2-cp36-cp36m-win_amd64.whl", hash = "sha256:a4d511012beb967a39580ba7d2549edf1e6865a33e5fe51e4dce550522b3ac0e"},
-    {file = "coverage-5.2-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:32ecee61a43be509b91a526819717d5e5650e009a8d5eda8631a59c721d5f3b6"},
-    {file = "coverage-5.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:6f91b4492c5cde83bfe462f5b2b997cdf96a138f7c58b1140f05de5751623cf1"},
-    {file = "coverage-5.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bfcc811883699ed49afc58b1ed9f80428a18eb9166422bce3c31a53dba00fd1d"},
-    {file = "coverage-5.2-cp37-cp37m-win32.whl", hash = "sha256:60a3d36297b65c7f78329b80120f72947140f45b5c7a017ea730f9112b40f2ec"},
-    {file = "coverage-5.2-cp37-cp37m-win_amd64.whl", hash = "sha256:12eaccd86d9a373aea59869bc9cfa0ab6ba8b1477752110cb4c10d165474f703"},
-    {file = "coverage-5.2-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:d82db1b9a92cb5c67661ca6616bdca6ff931deceebb98eecbd328812dab52032"},
-    {file = "coverage-5.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:214eb2110217f2636a9329bc766507ab71a3a06a8ea30cdeebb47c24dce5972d"},
-    {file = "coverage-5.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8a3decd12e7934d0254939e2bf434bf04a5890c5bf91a982685021786a08087e"},
-    {file = "coverage-5.2-cp38-cp38-win32.whl", hash = "sha256:1dcebae667b73fd4aa69237e6afb39abc2f27520f2358590c1b13dd90e32abe7"},
-    {file = "coverage-5.2-cp38-cp38-win_amd64.whl", hash = "sha256:f50632ef2d749f541ca8e6c07c9928a37f87505ce3a9f20c8446ad310f1aa87b"},
-    {file = "coverage-5.2-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:7403675df5e27745571aba1c957c7da2dacb537c21e14007ec3a417bf31f7f3d"},
-    {file = "coverage-5.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:0fc4e0d91350d6f43ef6a61f64a48e917637e1dcfcba4b4b7d543c628ef82c2d"},
-    {file = "coverage-5.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:25fe74b5b2f1b4abb11e103bb7984daca8f8292683957d0738cd692f6a7cc64c"},
-    {file = "coverage-5.2-cp39-cp39-win32.whl", hash = "sha256:d67599521dff98ec8c34cd9652cbcfe16ed076a2209625fca9dc7419b6370e5c"},
-    {file = "coverage-5.2-cp39-cp39-win_amd64.whl", hash = "sha256:10f2a618a6e75adf64329f828a6a5b40244c1c50f5ef4ce4109e904e69c71bd2"},
-    {file = "coverage-5.2.tar.gz", hash = "sha256:1874bdc943654ba46d28f179c1846f5710eda3aeb265ff029e0ac2b52daae404"},
+    {file = "coverage-5.1-cp27-cp27m-macosx_10_12_x86_64.whl", hash = "sha256:0cb4be7e784dcdc050fc58ef05b71aa8e89b7e6636b99967fadbdba694cf2b65"},
+    {file = "coverage-5.1-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:c317eaf5ff46a34305b202e73404f55f7389ef834b8dbf4da09b9b9b37f76dd2"},
+    {file = "coverage-5.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b83835506dfc185a319031cf853fa4bb1b3974b1f913f5bb1a0f3d98bdcded04"},
+    {file = "coverage-5.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5f2294dbf7875b991c381e3d5af2bcc3494d836affa52b809c91697449d0eda6"},
+    {file = "coverage-5.1-cp27-cp27m-win32.whl", hash = "sha256:de807ae933cfb7f0c7d9d981a053772452217df2bf38e7e6267c9cbf9545a796"},
+    {file = "coverage-5.1-cp27-cp27m-win_amd64.whl", hash = "sha256:bf9cb9a9fd8891e7efd2d44deb24b86d647394b9705b744ff6f8261e6f29a730"},
+    {file = "coverage-5.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:acf3763ed01af8410fc36afea23707d4ea58ba7e86a8ee915dfb9ceff9ef69d0"},
+    {file = "coverage-5.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:dec5202bfe6f672d4511086e125db035a52b00f1648d6407cc8e526912c0353a"},
+    {file = "coverage-5.1-cp35-cp35m-macosx_10_12_x86_64.whl", hash = "sha256:7a5bdad4edec57b5fb8dae7d3ee58622d626fd3a0be0dfceda162a7035885ecf"},
+    {file = "coverage-5.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1601e480b9b99697a570cea7ef749e88123c04b92d84cedaa01e117436b4a0a9"},
+    {file = "coverage-5.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:dbe8c6ae7534b5b024296464f387d57c13caa942f6d8e6e0346f27e509f0f768"},
+    {file = "coverage-5.1-cp35-cp35m-win32.whl", hash = "sha256:a027ef0492ede1e03a8054e3c37b8def89a1e3c471482e9f046906ba4f2aafd2"},
+    {file = "coverage-5.1-cp35-cp35m-win_amd64.whl", hash = "sha256:0e61d9803d5851849c24f78227939c701ced6704f337cad0a91e0972c51c1ee7"},
+    {file = "coverage-5.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:2d27a3f742c98e5c6b461ee6ef7287400a1956c11421eb574d843d9ec1f772f0"},
+    {file = "coverage-5.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:66460ab1599d3cf894bb6baee8c684788819b71a5dc1e8fa2ecc152e5d752019"},
+    {file = "coverage-5.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5c542d1e62eece33c306d66fe0a5c4f7f7b3c08fecc46ead86d7916684b36d6c"},
+    {file = "coverage-5.1-cp36-cp36m-win32.whl", hash = "sha256:2742c7515b9eb368718cd091bad1a1b44135cc72468c731302b3d641895b83d1"},
+    {file = "coverage-5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:dead2ddede4c7ba6cb3a721870f5141c97dc7d85a079edb4bd8d88c3ad5b20c7"},
+    {file = "coverage-5.1-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:01333e1bd22c59713ba8a79f088b3955946e293114479bbfc2e37d522be03355"},
+    {file = "coverage-5.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e1ea316102ea1e1770724db01998d1603ed921c54a86a2efcb03428d5417e489"},
+    {file = "coverage-5.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:adeb4c5b608574a3d647011af36f7586811a2c1197c861aedb548dd2453b41cd"},
+    {file = "coverage-5.1-cp37-cp37m-win32.whl", hash = "sha256:782caea581a6e9ff75eccda79287daefd1d2631cc09d642b6ee2d6da21fc0a4e"},
+    {file = "coverage-5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:00f1d23f4336efc3b311ed0d807feb45098fc86dee1ca13b3d6768cdab187c8a"},
+    {file = "coverage-5.1-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:402e1744733df483b93abbf209283898e9f0d67470707e3c7516d84f48524f55"},
+    {file = "coverage-5.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:a3f3654d5734a3ece152636aad89f58afc9213c6520062db3978239db122f03c"},
+    {file = "coverage-5.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6402bd2fdedabbdb63a316308142597534ea8e1895f4e7d8bf7476c5e8751fef"},
+    {file = "coverage-5.1-cp38-cp38-win32.whl", hash = "sha256:8fa0cbc7ecad630e5b0f4f35b0f6ad419246b02bc750de7ac66db92667996d24"},
+    {file = "coverage-5.1-cp38-cp38-win_amd64.whl", hash = "sha256:79a3cfd6346ce6c13145731d39db47b7a7b859c0272f02cdb89a3bdcbae233a0"},
+    {file = "coverage-5.1-cp39-cp39-win32.whl", hash = "sha256:a82b92b04a23d3c8a581fc049228bafde988abacba397d57ce95fe95e0338ab4"},
+    {file = "coverage-5.1-cp39-cp39-win_amd64.whl", hash = "sha256:bb28a7245de68bf29f6fb199545d072d1036a1917dca17a1e75bbb919e14ee8e"},
+    {file = "coverage-5.1.tar.gz", hash = "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"},
 ]
 django = [
     {file = "Django-1.11.29-py2.py3-none-any.whl", hash = "sha256:014e3392058d94f40569206a24523ce254d55ad2f9f46c6550b0fe2e4f94cf3f"},
     {file = "Django-1.11.29.tar.gz", hash = "sha256:4200aefb6678019a0acf0005cd14cfce3a5e6b9b90d06145fcdd2e474ad4329c"},
-    {file = "Django-2.2.14-py3-none-any.whl", hash = "sha256:f2250bd35d0f6c23e930c544629934144e5dd39a4c06092e1050c731c1712ba8"},
-    {file = "Django-2.2.14.tar.gz", hash = "sha256:edf0ecf6657713b0435b6757e6069466925cae70d634a3283c96b80c01e06191"},
+    {file = "Django-2.2.13-py3-none-any.whl", hash = "sha256:e8fe3c2b2212dce6126becab7a693157f1a441a07b62ec994c046c76af5bb66d"},
+    {file = "Django-2.2.13.tar.gz", hash = "sha256:84f370f6acedbe1f3c41e1a02de44ac206efda3355e427139ecb785b5f596d80"},
 ]
 enum34 = [
     {file = "enum34-1.1.10-py2-none-any.whl", hash = "sha256:a98a201d6de3f2ab3db284e70a33b0f896fbf35f8086594e8c9e74b909058d53"},
@@ -653,28 +651,24 @@ lazy-object-proxy = [
     {file = "lazy_object_proxy-1.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62"},
     {file = "lazy_object_proxy-1.4.3-cp38-cp38-win32.whl", hash = "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd"},
     {file = "lazy_object_proxy-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239"},
-    {file = "lazy-object-proxy-1.5.1.tar.gz", hash = "sha256:9723364577b79ad9958a68851fe2acb94da6fd25170c595516a8289e6a129043"},
-    {file = "lazy_object_proxy-1.5.1-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:92cedd6e26712505adb1c17fab64651a498cc0102a80ba562ff4a2451088f57a"},
-    {file = "lazy_object_proxy-1.5.1-cp27-cp27m-win32.whl", hash = "sha256:ef355fb3802e0fc5a71dadb65a3c317bfc9bdf567d357f8e0b1900b432ffe486"},
-    {file = "lazy_object_proxy-1.5.1-cp27-cp27m-win_amd64.whl", hash = "sha256:3e8698dc384857413580012f4ca322d89e63ef20fc3d4635a5b606d6d4b61f6a"},
-    {file = "lazy_object_proxy-1.5.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:edbcb4c5efabd93ede05b272296a5a78a67e9b6e82ba7f51a07b8103db06ce01"},
-    {file = "lazy_object_proxy-1.5.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:33da47ba3a581860ddd3d38c950a5fe950ca389f7123edd0d6ab0bc473499fe7"},
-    {file = "lazy_object_proxy-1.5.1-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:c697bd1b333b3e6abdff04ef9f5fb4b1936633d9cc4e28d90606705c9083254c"},
-    {file = "lazy_object_proxy-1.5.1-cp35-cp35m-win32.whl", hash = "sha256:8133b63b05f12751cddd8e3e7f02ba39dc7cfa7d2ba99d80d7436f0ba26d6b75"},
-    {file = "lazy_object_proxy-1.5.1-cp35-cp35m-win_amd64.whl", hash = "sha256:30ef2068f4f94660144515380ef04b93d15add2214eab8be4cd46ebc900d681c"},
-    {file = "lazy_object_proxy-1.5.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:042b54fd71c2092e6d10e5e66fa60f65c5954f8145e809f5d9f394c9b13d32ee"},
-    {file = "lazy_object_proxy-1.5.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:db2df3eff7ed3e6813638686f1bb5934d1a0662d9d3b4196b5164a86be3a1e8f"},
-    {file = "lazy_object_proxy-1.5.1-cp36-cp36m-win32.whl", hash = "sha256:4fdd7113fc5143c72dacf415079eec42fcbe69cc9d3d291b4ca742e3a9455807"},
-    {file = "lazy_object_proxy-1.5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:11f87dc06eb5f376cc6d5f0c19a1b4dca202035622777c4ce8e5b72c87b035d6"},
-    {file = "lazy_object_proxy-1.5.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:22c1935c6f8e3d6ea2e169eb03928adbdb8a2251d2890f8689368d65e70aa176"},
-    {file = "lazy_object_proxy-1.5.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:19ae6f6511a02008ef3554e158c41bb2a8e5c8455935b98d6da076d9f152fd7c"},
-    {file = "lazy_object_proxy-1.5.1-cp37-cp37m-win32.whl", hash = "sha256:8d82e27cbbea6edb8821751806f39f5dcfd7b46a5e23d27b98d6d8c8ec751df8"},
-    {file = "lazy_object_proxy-1.5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:c484020ad26973a14a7cb1e1d2e0bfe97cf6803273ae9bd154e0213cc74bad49"},
-    {file = "lazy_object_proxy-1.5.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:fe2f61fed5817bf8db01d9a72309ed5990c478a077e9585b58740c26774bce39"},
-    {file = "lazy_object_proxy-1.5.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:63b6d9a5077d54db271fcc6772440f7380ec3fa559d0e2497dbfae2f47c2c814"},
-    {file = "lazy_object_proxy-1.5.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:d0f7e14ff3424639d33e6bc449e77e4b345e52c21bbd6f6004a1d219196e2664"},
-    {file = "lazy_object_proxy-1.5.1-cp38-cp38-win32.whl", hash = "sha256:89b8e5780e49753e2b4cd5aab45d3df092ddcbba3de2c4d4492a029588fe1758"},
-    {file = "lazy_object_proxy-1.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:00b78a97a79d0dfefa584d44dd1aba9668d3de7ec82335ba0ff51d53ef107143"},
+    {file = "lazy-object-proxy-1.5.0.tar.gz", hash = "sha256:a0aed261060cd0372abf08d16399b1224dbb5b400312e6b00f2b23eabe1d4e96"},
+    {file = "lazy_object_proxy-1.5.0-cp27-cp27m-macosx_10_13_x86_64.whl", hash = "sha256:ec6aba217d0c4f71cbe48aea962a382dedcd111f47b55e8b58d4aaca519bd360"},
+    {file = "lazy_object_proxy-1.5.0-cp27-cp27m-win32.whl", hash = "sha256:e9a571e7168076a0d5ecaabd91e9032e86d815cca3a4bf0dafead539ef071aa5"},
+    {file = "lazy_object_proxy-1.5.0-cp27-cp27m-win_amd64.whl", hash = "sha256:e3183fbeb452ec11670c2d9bfd08a57bc87e46856b24d1c335f995239bedd0e1"},
+    {file = "lazy_object_proxy-1.5.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:96f2cdb35bdfda10e075f12892a42cff5179bbda698992b845f36c5e92755d33"},
+    {file = "lazy_object_proxy-1.5.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:51035b175740c44707694c521560b55b66da9d5a7c545cf22582bc02deb61664"},
+    {file = "lazy_object_proxy-1.5.0-cp35-cp35m-win32.whl", hash = "sha256:2d58f0e6395bf41087a383a48b06b42165f3b699f1aa41ba201db84ab77be63d"},
+    {file = "lazy_object_proxy-1.5.0-cp35-cp35m-win_amd64.whl", hash = "sha256:cbf1354292a4f7abb6a0188f74f5e902e4510ebad105be1dbc4809d1ed92f77e"},
+    {file = "lazy_object_proxy-1.5.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:459ef557e669d0046fe2b92eb4822c097c00b5ef9d11df0f9bd7d4267acdfc52"},
+    {file = "lazy_object_proxy-1.5.0-cp36-cp36m-win32.whl", hash = "sha256:dd89f466c930d7cfe84c94b5cbe862867c88b269f23e5aa61d40945e0d746f54"},
+    {file = "lazy_object_proxy-1.5.0-cp36-cp36m-win_amd64.whl", hash = "sha256:4a50513b6be001b9b7be2c435478fe9669249c77c241813907a44cda1fcd03f4"},
+    {file = "lazy_object_proxy-1.5.0-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:159ae2bbb4dc3ba506aeba868d14e56a754c0be402d1f0d7fdb264e0bdf2b095"},
+    {file = "lazy_object_proxy-1.5.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:161a68a427022bf13e249458be2cb8da56b055988c584d372a917c665825ae9a"},
+    {file = "lazy_object_proxy-1.5.0-cp37-cp37m-win32.whl", hash = "sha256:311c9d1840042fc8e2dd80fc80272a7ea73e7646745556153c9cda85a4628b18"},
+    {file = "lazy_object_proxy-1.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:0aef3fa29f7d1194d6f8a99382b1b844e5a14d3bc1ef82c3b1c4fb7e7e2019bc"},
+    {file = "lazy_object_proxy-1.5.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:a6052c4c7d95de2345d9c58fc0fe34fff6c27a8ed8550dafeb18ada84406cc99"},
+    {file = "lazy_object_proxy-1.5.0-cp38-cp38-win32.whl", hash = "sha256:da82b2372f5ded8806eaac95b19af89a7174efdb418d4e7beb0c6ab09cee7d95"},
+    {file = "lazy_object_proxy-1.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:35c3ad7b7f7d5d4a54a80f0ff5a41ab186237d6486843f8dde00c42cfab33905"},
 ]
 libhoney = [
     {file = "libhoney-1.9.0.tar.gz", hash = "sha256:b70010f9c37fed4e27708a1b16f1dc6de9486dd21c9a986b3764f84b3c944fee"},
@@ -797,8 +791,8 @@ typed-ast = [
 urllib3 = [
     {file = "urllib3-1.22-py2.py3-none-any.whl", hash = "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b"},
     {file = "urllib3-1.22.tar.gz", hash = "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"},
-    {file = "urllib3-1.25.10-py2.py3-none-any.whl", hash = "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"},
-    {file = "urllib3-1.25.10.tar.gz", hash = "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a"},
+    {file = "urllib3-1.25.9-py2.py3-none-any.whl", hash = "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"},
+    {file = "urllib3-1.25.9.tar.gz", hash = "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527"},
 ]
 werkzeug = [
     {file = "Werkzeug-1.0.1-py2.py3-none-any.whl", hash = "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "honeycomb-beeline"
-version = "2.12.2" # Update using bump2version
+version = "2.13.0-dev0" # Update using bump2version
 description = "Honeycomb library for easy instrumentation"
 authors = ["Honeycomb.io <feedback@honeycomb.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
PR for implementing user-customizable hooks for HTTP header parsing and propagation.

Per discussion with @paulosman, the goal here is to get the code change in. We know that we will want to improve the tests and the documentation, but since the overall test quality/documentation here is poor we don't want to make this PR bigger with testing.

I have done manual testing by implementing python services in https://github.com/honeycombio/example-greeting-service/pull/1 - these will hopefully become the foundation of integration tests that will make our automated testing situation more robust in the future.

### Hook-related changes
* New `beeline` configuration parameters for `http_trace_parse_hook` and `http_trace_propagation_hook`
* New `propagate_and_start_trace` function for use by middleware to invoke the `http_trace_parse_hook`
* New `beeline.propagation` package to centralize propagation-related classes and functions.
* Implement `beeline.propagation.Request` classes for middleware to aid in support of header and propagation hooks.
* Migrate existing middleware to use new `beeline.propagation` classes and functions so that they support http_trace_parse_hooks.
* Centralize duplicated code for WSGI variants (Flask, Bottle, Werkzeug) into a single place.
* Added http_trace_propagation_hook support to requests and urllib.
* "Deprecate" the existing, misnamed `trace_context` related functions, and migrate all internal usage to the new `beeline.propagation.honeycomb` functions. These will ideally go away when we cut the next major version of the Python beeline, whenever that is.

### Bug fixes
* Fixed a bug where `urllib.request.urlopen` would fail if given a string URL as an argument.

### Misc
* Bumped version to 2.13.0-dev0

### TODOs:
* Improve test coverage of new code
* Improved documentation for hooks