### PR TITLE
w3c hooks and basic tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,27 @@
 
 ### Features
 
-We have added new functionality for `http_trace_parse_hook` and `http_trace_propagation_hook`. These features allow beeline users to process incoming tracing-related headers, allowing for eventual interoperability between Honeycomb, OpenTelemetry (W3C) and other tracing formats.
+We have added new functionality for `http_trace_parse_hook` and `http_trace_propagation_hook`. These hooks allow beeline users
+to parse incoming headers, as well as add outgoing headers, allowing for interoperability between Honeycomb,
+OpenTelemetry (W3C) and other tracing formats.
 
 - New `beeline` configuration parameters for `http_trace_parse_hook` and `http_trace_propagation_hook`
 - New `propagate_and_start_trace` function for use by middleware to invoke the `http_trace_parse_hook`
 - New `beeline.propagation` package to centralize propagation-related classes and functions.
+- `beeline.propagation.honeycomb` package contains hooks to support parsing and propagation using honeycomb headers.
+- `beeline.propagation.w3c` package contains hooks to support parsing and propagation using w3c headers.
+
+### Deprecation Notice
+
+- Deprecated the existing `beeline.marshal_trace_context`, and migrated all usage to new
+  `beeline.propagation.honeycomb` functions. `beeline.marshal_trace_context` will be removed when the next major version of the beeline is released.
+
+### Implementation details
+
 - Implemented `beeline.propagation.Request` classes for middleware to aid in support of header and propagation hooks.
-- Migrateed existing middleware to use new `beeline.propagation` classes and functions so that they support `http_trace_parse_hooks`.
-- Centralized duplicated code for WSGI variants (Flask, Bottle, Werkzeug) into a single place.
+- Migrateed existing middleware to use new `beeline.propagation` classes and functions to support `http_trace_parse_hooks`.
+- Centralized duplicated code for WSGI variants (Flask, Bottle, Werkzeug) into a single location.
 - Added `http_trace_propagation_hook` support to requests and urllib.
-- Deprecate the existing, misnamed `trace_context` related functions, and migrate all internal usage to the new `beeline.propagation.honeycomb` functions. These will be removed when the next major version of the beeline is released.
 
 ### Fixes
 

--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -623,9 +623,11 @@ def http_trace_propagation_hook():
 
 def marshal_trace_context():
     '''
-    Returns a serialized form of the current trace context (including the trace
+    DEPRECATED: Returns a serialized form of the current trace context (including the trace
     id and the current span), encoded as a string. You can use this to propagate
     trace context to other services.
+
+    Use `beeline.propagation.honeycomb` functions to work with honeycomb trace context instead.
 
     Example:
 

--- a/beeline/propagation/test_w3c.py
+++ b/beeline/propagation/test_w3c.py
@@ -1,0 +1,73 @@
+import unittest
+from beeline.propagation import DictRequest, PropagationContext
+import beeline.propagation.honeycomb as hc
+import beeline.propagation.w3c as w3c
+
+traceparent_header = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00"
+tracestate_header = "foo=bar,bar=baz"
+
+headers = {
+    "traceparent": traceparent_header,
+    "tracestate": tracestate_header
+}
+trace_id = "0af7651916cd43dd8448eb211c80319c"
+parent_id = "b7ad6b7169203331"
+trace_flags = "00"
+tracestate = "foo=bar,bar=baz"
+
+
+class TestW3CMarshalUnmarshal(unittest.TestCase):
+    def test_roundtrip(self):
+        '''Verify that we can successfully roundtrip (marshal and unmarshal)'''
+        trace_fields = {"traceflags": trace_flags,
+                        "tracestate": tracestate}
+
+        pc = PropagationContext(trace_id, parent_id, trace_fields)
+
+        traceparent_header = w3c.marshal_traceparent(pc)
+        self.assertEquals(traceparent_header, traceparent_header)
+
+        tracestate_header = w3c.marshal_tracestate(pc)
+        self.assertEquals(tracestate_header, tracestate_header)
+
+        new_trace_id, new_parent_id, new_trace_flags = w3c.unmarshal_traceparent(
+            traceparent_header)
+        self.assertEquals(trace_id, new_trace_id)
+        self.assertEquals(parent_id, new_parent_id)
+        self.assertEquals(trace_flags, new_trace_flags)
+
+        new_tracestate = w3c.unmarshal_tracestate(tracestate_header)
+        self.assertEquals(tracestate, new_tracestate)
+
+
+class TestW3CHTTPTraceParserHook(unittest.TestCase):
+    def test_has_header(self):
+        '''Test that the hook properly parses honeycomb trace headers'''
+        req = DictRequest(headers)
+        pc = w3c.http_trace_parser_hook(req)
+        self.assertEquals(pc.trace_id, trace_id)
+        self.assertEquals(pc.parent_id, parent_id)
+        self.assertEquals(pc.trace_fields, {
+            "tracestate": tracestate,
+            "traceflags": trace_flags
+        })
+
+    def test_no_header(self):
+        req = DictRequest({})
+        pc = w3c.http_trace_parser_hook(req)
+        self.assertIsNone(pc)
+
+
+class TestW3CHTTPTracePropagationHook(unittest.TestCase):
+    def test_generates_correct_headers(self):
+        pc = PropagationContext(
+            trace_id, parent_id, {"traceflags": trace_flags,
+                                  "tracestate": tracestate}
+        )
+        headers = w3c.http_trace_propagation_hook(pc)
+        self.assertIn('traceparent', headers)
+        self.assertIn('tracestate', headers)
+        self.assertEquals(headers['traceparent'],
+                          traceparent_header)
+        self.assertEquals(headers['tracestate'],
+                          tracestate_header)

--- a/beeline/propagation/test_w3c.py
+++ b/beeline/propagation/test_w3c.py
@@ -24,19 +24,21 @@ class TestW3CMarshalUnmarshal(unittest.TestCase):
 
         pc = PropagationContext(_TEST_TRACE_ID, _TEST_PARENT_ID, trace_fields)
 
-        _TEST_TRACEPARENT_HEADER = w3c.marshal_traceparent(pc)
-        self.assertEquals(_TEST_TRACEPARENT_HEADER, _TEST_TRACEPARENT_HEADER)
+        traceparent_header = w3c.marshal_traceparent(pc)
+        tracestate_header = w3c.marshal_tracestate(pc)
 
-        _TEST_TRACESTATE_HEADER = w3c.marshal_tracestate(pc)
-        self.assertEquals(_TEST_TRACESTATE_HEADER, _TEST_TRACESTATE_HEADER)
+        # Make sure marshalled headers are as we expect.
+        self.assertEquals(_TEST_TRACEPARENT_HEADER, traceparent_header)
+        self.assertEquals(_TEST_TRACESTATE_HEADER, tracestate_header)
 
         new_trace_id, new_parent_id, new_trace_flags = w3c.unmarshal_traceparent(
-            _TEST_TRACEPARENT_HEADER)
+            traceparent_header)
+        new_tracestate = w3c.unmarshal_tracestate(tracestate_header)
+
+        # Check round-trip values are the same as start values.
         self.assertEquals(_TEST_TRACE_ID, new_trace_id)
         self.assertEquals(_TEST_PARENT_ID, new_parent_id)
         self.assertEquals(_TEST_TRACE_FLAGS, new_trace_flags)
-
-        new_tracestate = w3c.unmarshal_tracestate(_TEST_TRACESTATE_HEADER)
         self.assertEquals(_TEST_TRACESTATE, new_tracestate)
 
 

--- a/beeline/propagation/test_w3c.py
+++ b/beeline/propagation/test_w3c.py
@@ -3,53 +3,53 @@ from beeline.propagation import DictRequest, PropagationContext
 import beeline.propagation.honeycomb as hc
 import beeline.propagation.w3c as w3c
 
-traceparent_header = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00"
-tracestate_header = "foo=bar,bar=baz"
+_TEST_TRACEPARENT_HEADER = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00"
+_TEST_TRACESTATE_HEADER = "foo=bar,bar=baz"
 
-headers = {
-    "traceparent": traceparent_header,
-    "tracestate": tracestate_header
+_TEST_HEADERS = {
+    "traceparent": _TEST_TRACEPARENT_HEADER,
+    "tracestate": _TEST_TRACESTATE_HEADER
 }
-trace_id = "0af7651916cd43dd8448eb211c80319c"
-parent_id = "b7ad6b7169203331"
-trace_flags = "00"
-tracestate = "foo=bar,bar=baz"
+_TEST_TRACE_ID = "0af7651916cd43dd8448eb211c80319c"
+_TEST_PARENT_ID = "b7ad6b7169203331"
+_TEST_TRACE_FLAGS = "00"
+_TEST_TRACESTATE = "foo=bar,bar=baz"
 
 
 class TestW3CMarshalUnmarshal(unittest.TestCase):
     def test_roundtrip(self):
         '''Verify that we can successfully roundtrip (marshal and unmarshal)'''
-        trace_fields = {"traceflags": trace_flags,
-                        "tracestate": tracestate}
+        trace_fields = {"traceflags": _TEST_TRACE_FLAGS,
+                        "tracestate": _TEST_TRACESTATE}
 
-        pc = PropagationContext(trace_id, parent_id, trace_fields)
+        pc = PropagationContext(_TEST_TRACE_ID, _TEST_PARENT_ID, trace_fields)
 
-        traceparent_header = w3c.marshal_traceparent(pc)
-        self.assertEquals(traceparent_header, traceparent_header)
+        _TEST_TRACEPARENT_HEADER = w3c.marshal_traceparent(pc)
+        self.assertEquals(_TEST_TRACEPARENT_HEADER, _TEST_TRACEPARENT_HEADER)
 
-        tracestate_header = w3c.marshal_tracestate(pc)
-        self.assertEquals(tracestate_header, tracestate_header)
+        _TEST_TRACESTATE_HEADER = w3c.marshal_tracestate(pc)
+        self.assertEquals(_TEST_TRACESTATE_HEADER, _TEST_TRACESTATE_HEADER)
 
         new_trace_id, new_parent_id, new_trace_flags = w3c.unmarshal_traceparent(
-            traceparent_header)
-        self.assertEquals(trace_id, new_trace_id)
-        self.assertEquals(parent_id, new_parent_id)
-        self.assertEquals(trace_flags, new_trace_flags)
+            _TEST_TRACEPARENT_HEADER)
+        self.assertEquals(_TEST_TRACE_ID, new_trace_id)
+        self.assertEquals(_TEST_PARENT_ID, new_parent_id)
+        self.assertEquals(_TEST_TRACE_FLAGS, new_trace_flags)
 
-        new_tracestate = w3c.unmarshal_tracestate(tracestate_header)
-        self.assertEquals(tracestate, new_tracestate)
+        new_tracestate = w3c.unmarshal_tracestate(_TEST_TRACESTATE_HEADER)
+        self.assertEquals(_TEST_TRACESTATE, new_tracestate)
 
 
 class TestW3CHTTPTraceParserHook(unittest.TestCase):
     def test_has_header(self):
-        '''Test that the hook properly parses honeycomb trace headers'''
-        req = DictRequest(headers)
+        '''Test that the hook properly parses W3C trace headers'''
+        req = DictRequest(_TEST_HEADERS)
         pc = w3c.http_trace_parser_hook(req)
-        self.assertEquals(pc.trace_id, trace_id)
-        self.assertEquals(pc.parent_id, parent_id)
+        self.assertEquals(pc.trace_id, _TEST_TRACE_ID)
+        self.assertEquals(pc.parent_id, _TEST_PARENT_ID)
         self.assertEquals(pc.trace_fields, {
-            "tracestate": tracestate,
-            "traceflags": trace_flags
+            "tracestate": _TEST_TRACESTATE,
+            "traceflags": _TEST_TRACE_FLAGS
         })
 
     def test_no_header(self):
@@ -61,13 +61,13 @@ class TestW3CHTTPTraceParserHook(unittest.TestCase):
 class TestW3CHTTPTracePropagationHook(unittest.TestCase):
     def test_generates_correct_headers(self):
         pc = PropagationContext(
-            trace_id, parent_id, {"traceflags": trace_flags,
-                                  "tracestate": tracestate}
+            _TEST_TRACE_ID, _TEST_PARENT_ID, {"traceflags": _TEST_TRACE_FLAGS,
+                                              "tracestate": _TEST_TRACESTATE}
         )
         headers = w3c.http_trace_propagation_hook(pc)
         self.assertIn('traceparent', headers)
         self.assertIn('tracestate', headers)
         self.assertEquals(headers['traceparent'],
-                          traceparent_header)
+                          _TEST_TRACEPARENT_HEADER)
         self.assertEquals(headers['tracestate'],
-                          tracestate_header)
+                          _TEST_TRACESTATE_HEADER)

--- a/beeline/propagation/w3c.py
+++ b/beeline/propagation/w3c.py
@@ -8,6 +8,8 @@ _TRACEPARENT_HEADER_FORMAT = (
     + "(-.*)?[ \t]*$"
 )
 _TRACEPARENT_HEADER_FORMAT_RE = re.compile(_TRACEPARENT_HEADER_FORMAT)
+_EMPTY_TRACE_ID = "0" * 32
+_EMPTY_PARENT_ID = "0" * 16
 
 
 def http_trace_parser_hook(request):
@@ -70,8 +72,6 @@ def marshal_traceparent(propagation_context):
     if not trace_flags:
         trace_flags = "00"
 
-    # FIXME: Validate that trace id and parent id are of the
-    # correct length and value?
     traceparent_header = "00-{}-{}-{}".format(
         propagation_context.trace_id,
         propagation_context.parent_id,
@@ -101,16 +101,13 @@ def unmarshal_traceparent(header):
     parent_id = match.group(3)
     trace_flags = match.group(4)
 
-    if trace_id == "0" * 32 or parent_id == "0" * 16:
-        # Raise exception?
+    if trace_id == _EMPTY_TRACE_ID or parent_id == _EMPTY_PARENT_ID:
         return None
 
     if version == "00":
         if match.group(5):
-            # Raise exception?
             return None
     if version == "ff":
-        # Raise exception?
         return None
 
     return trace_id, parent_id, trace_flags

--- a/beeline/propagation/w3c.py
+++ b/beeline/propagation/w3c.py
@@ -43,8 +43,18 @@ def http_trace_propagation_hook(propagation_context):
     if not propagation_context:
         return None
 
-    return {"traceparent": marshal_traceparent(propagation_context),
-            "tracestate": marshal_tracestate(propagation_context)}
+    traceparent_header = marshal_traceparent(propagation_context)
+    if not traceparent_header:
+        return {}
+
+    headers = {}
+    headers["traceparent"] = traceparent_header
+
+    tracestate_header = marshal_tracestate(propagation_context)
+
+    if tracestate_header:
+        headers['tracestate'] = tracestate_header
+    return headers
 
 
 def marshal_traceparent(propagation_context):
@@ -55,7 +65,9 @@ def marshal_traceparent(propagation_context):
     if not propagation_context:
         return None
 
-    trace_flags = propagation_context.trace_fields['traceflags']
+    trace_flags = propagation_context.trace_fields.get('traceflags')
+    if not trace_flags:
+        trace_flags = "00"
 
     # FIXME: Validate that trace id and parent id are of the
     # correct length and value?
@@ -74,7 +86,7 @@ def marshal_tracestate(propagation_context):
     if not propagation_context:
         return None
 
-    tracestate_header = propagation_context.trace_fields['tracestate']
+    tracestate_header = propagation_context.trace_fields.get('tracestate')
     return tracestate_header
 
 

--- a/beeline/propagation/w3c.py
+++ b/beeline/propagation/w3c.py
@@ -1,0 +1,108 @@
+import beeline
+from beeline.propagation import PropagationContext
+import re
+
+_TRACEPARENT_HEADER_FORMAT = (
+    "^[ \t]*([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})"
+    + "(-.*)?[ \t]*$"
+)
+_TRACEPARENT_HEADER_FORMAT_RE = re.compile(_TRACEPARENT_HEADER_FORMAT)
+
+
+def http_trace_parser_hook(request):
+    '''
+    Retrieves the w3c propagation context out of the request.
+    request must implement the beeline.propagation.Request abstract base class
+    '''
+    traceparent_header = request.header('traceparent')
+    if not traceparent_header:
+        return None
+    tracestate_header = request.header('tracestate')
+
+    trace_id = None
+    parent_id = None
+    try:
+        trace_id, parent_id, trace_flags = unmarshal_traceparent(
+            traceparent_header)
+        tracestate = unmarshal_tracestate(tracestate_header)
+        trace_fields = {}
+        trace_fields['traceflags'] = trace_flags
+        trace_fields['tracestate'] = tracestate
+        return PropagationContext(trace_id, parent_id, trace_fields)
+    except Exception as e:
+        beeline.internal.log(
+            'error attempting to extract w3c trace: %s', beeline.internal.stringify_exception(e))
+    return None
+
+
+def http_trace_propagation_hook(propagation_context):
+    '''
+    Given a propagation context, returns a dictionary of key value pairs that should be
+    added to outbound requests (usually HTTP headers)
+    '''
+    if not propagation_context:
+        return None
+
+    return {"traceparent": marshal_traceparent(propagation_context),
+            "tracestate": marshal_tracestate(propagation_context)}
+
+
+def marshal_traceparent(propagation_context):
+    '''
+    Given a propagation context, returns the contents of a trace header to be
+    injected by middleware.
+    '''
+    if not propagation_context:
+        return None
+
+    trace_flags = propagation_context.trace_fields['traceflags']
+
+    # FIXME: Validate that trace id and parent id are of the
+    # correct length and value?
+    traceparent_header = "00-{}-{}-{}".format(
+        propagation_context.trace_id,
+        propagation_context.parent_id,
+        trace_flags,
+    )
+
+    return traceparent_header
+
+
+def marshal_tracestate(propagation_context):
+    '''
+    '''
+    if not propagation_context:
+        return None
+
+    tracestate_header = propagation_context.trace_fields['tracestate']
+    return tracestate_header
+
+
+def unmarshal_traceparent(header):
+    match = re.search(_TRACEPARENT_HEADER_FORMAT_RE, header)
+    if not match:
+        # Raise exception?
+        return None
+    version = match.group(1)
+    trace_id = match.group(2)
+    parent_id = match.group(3)
+    trace_flags = match.group(4)
+
+    if trace_id == "0" * 32 or parent_id == "0" * 16:
+        # Raise exception?
+        return None
+
+    if version == "00":
+        if match.group(5):
+            # Raise exception?
+            return None
+    if version == "ff":
+        # Raise exception?
+        return None
+
+    return trace_id, parent_id, trace_flags
+
+
+def unmarshal_tracestate(header):
+    # We treat the tracestate header as an opaque blob, and don't parse it at all.
+    return header

--- a/beeline/propagation/w3c.py
+++ b/beeline/propagation/w3c.py
@@ -2,6 +2,7 @@ import beeline
 from beeline.propagation import PropagationContext
 import re
 
+# Cribbed from OpenTelemetry python implementation.
 _TRACEPARENT_HEADER_FORMAT = (
     "^[ \t]*([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})"
     + "(-.*)?[ \t]*$"


### PR DESCRIPTION
This implements w3c-compatible trace header hooks on top of the new `http_trace_parser_hook` and `http_trace_propagation_hook`.

Note that this is the minimal implementation for interoperability - it only propagates traceflags and tracestate, not making any attempt to parse them or add to them.

I have implemented basic tests, and verified by running them the example-greeting-service and verifying that it works to create a valid trace when inserted between otel go services.