### PR TITLE
Update Lambda wrapper to allow omission of input/output fields

### DIFF
--- a/beeline/middleware/awslambda/test_awslambda.py
+++ b/beeline/middleware/awslambda/test_awslambda.py
@@ -198,7 +198,7 @@ class TestLambdaWrapper(unittest.TestCase):
                 'app.function_name': 'fn',
                 'app.function_version': '1.1.1',
                 'app.request_id': '12345',
-                'app.event': ANY, # 'app.event' is included by default
+                'app.event': ANY,  # 'app.event' is included by default
                 'meta.cold_start': ANY,
                 'name': 'handler'}, ANY)
             m_add_context_field.assert_called_once_with('app.response', 1)
@@ -225,7 +225,6 @@ class TestLambdaWrapper(unittest.TestCase):
                 'meta.cold_start': ANY,
                 'name': 'handler'}, ANY)  # note the lack of an 'app.event' field
             m_add_context_field.assert_called_once_with('app.response', 1)
-
 
     def test_can_omit_output(self):
         ''' ensure output event fields can be omitted '''

--- a/beeline/middleware/awslambda/test_awslambda.py
+++ b/beeline/middleware/awslambda/test_awslambda.py
@@ -203,8 +203,8 @@ class TestLambdaWrapper(unittest.TestCase):
                 'name': 'handler'}, ANY)
             m_add_context_field.assert_called_once_with('app.response', 1)
 
-    def test_can_omit_input_output(self):
-        ''' ensure input and output event fields can be omitted '''
+    def test_can_omit_input(self):
+        ''' ensure input event field can be omitted '''
         with patch('beeline.propagate_and_start_trace') as m_propagate, \
                 patch('beeline.add_context_field') as m_add_context_field, \
                 patch('beeline.middleware.awslambda.beeline._GBL'), \
@@ -224,4 +224,29 @@ class TestLambdaWrapper(unittest.TestCase):
                 'app.request_id': '12345',
                 'meta.cold_start': ANY,
                 'name': 'handler'}, ANY)  # note the lack of an 'app.event' field
+            m_add_context_field.assert_called_once_with('app.response', 1)
+
+
+    def test_can_omit_output(self):
+        ''' ensure output event fields can be omitted '''
+        with patch('beeline.propagate_and_start_trace') as m_propagate, \
+                patch('beeline.add_context_field') as m_add_context_field, \
+                patch('beeline.middleware.awslambda.beeline._GBL'), \
+                patch('beeline.middleware.awslambda.COLD_START') as m_cold_start:
+            m_event = Mock()
+            m_context = Mock(function_name='fn', function_version="1.1.1",
+                             aws_request_id='12345')
+
+            @awslambda.beeline_wrapper(record_output=False)
+            def handler(event, context):
+                return 1
+
+            self.assertEqual(handler(m_event, m_context), 1)
+            m_propagate.assert_called_once_with({
+                'app.function_name': 'fn',
+                'app.function_version': '1.1.1',
+                'app.request_id': '12345',
+                'app.event': ANY,  # 'app.event' is included by default
+                'meta.cold_start': ANY,
+                'name': 'handler'}, ANY)
             m_add_context_field.not_called_with('app.response', 1)

--- a/beeline/middleware/awslambda/test_awslambda.py
+++ b/beeline/middleware/awslambda/test_awslambda.py
@@ -174,10 +174,10 @@ class TestLambdaWrapper(unittest.TestCase):
             self.assertEqual(foo(None, None), 1)
 
             @awslambda.beeline_wrapper()
-            def foo(event, context):
+            def bar(event, context):
                 return 1
 
-            self.assertEqual(foo(None, None), 1)
+            self.assertEqual(bar(None, None), 1)
 
     def test_basic_instrumentation(self):
         ''' ensure basic event fields get instrumented '''

--- a/beeline/middleware/awslambda/test_awslambda.py
+++ b/beeline/middleware/awslambda/test_awslambda.py
@@ -173,10 +173,17 @@ class TestLambdaWrapper(unittest.TestCase):
 
             self.assertEqual(foo(None, None), 1)
 
+            @awslambda.beeline_wrapper()
+            def foo(event, context):
+                return 1
+
+            self.assertEqual(foo(None, None), 1)
+
     def test_basic_instrumentation(self):
         ''' ensure basic event fields get instrumented '''
-        with patch('beeline.propagate_and_start_trace') as m_propagate,\
-                patch('beeline.middleware.awslambda.beeline._GBL'),\
+        with patch('beeline.propagate_and_start_trace') as m_propagate, \
+                patch('beeline.add_context_field') as m_add_context_field, \
+                patch('beeline.middleware.awslambda.beeline._GBL'), \
                 patch('beeline.middleware.awslambda.COLD_START') as m_cold_start:
             m_event = Mock()
             m_context = Mock(function_name='fn', function_version="1.1.1",
@@ -191,6 +198,30 @@ class TestLambdaWrapper(unittest.TestCase):
                 'app.function_name': 'fn',
                 'app.function_version': '1.1.1',
                 'app.request_id': '12345',
-                'app.event': ANY,
+                'app.event': ANY, # 'app.event' is included by default
                 'meta.cold_start': ANY,
                 'name': 'handler'}, ANY)
+            m_add_context_field.assert_called_once_with('app.response', 1)
+
+    def test_can_omit_input_output(self):
+        ''' ensure input and output event fields can be omitted '''
+        with patch('beeline.propagate_and_start_trace') as m_propagate, \
+                patch('beeline.add_context_field') as m_add_context_field, \
+                patch('beeline.middleware.awslambda.beeline._GBL'), \
+                patch('beeline.middleware.awslambda.COLD_START') as m_cold_start:
+            m_event = Mock()
+            m_context = Mock(function_name='fn', function_version="1.1.1",
+                             aws_request_id='12345')
+
+            @awslambda.beeline_wrapper(record_input=False)
+            def handler(event, context):
+                return 1
+
+            self.assertEqual(handler(m_event, m_context), 1)
+            m_propagate.assert_called_once_with({
+                'app.function_name': 'fn',
+                'app.function_version': '1.1.1',
+                'app.request_id': '12345',
+                'meta.cold_start': ANY,
+                'name': 'handler'}, ANY)  # note the lack of an 'app.event' field
+            m_add_context_field.not_called_with('app.response', 1)


### PR DESCRIPTION
Currently the Lambda wrapper always records the incoming event and the lambda response (if present).
That behavior may be undesirable if the input/output is very large.

This PR updates the Lambda wrapper to include two parameters (`record_input` and `record_output`) which allow the customization of that behavior.  These parameters default to `True`, leaving the default behavior unchanged.
