### PR TITLE
Add app.exception_traceback to context when an exception is thrown

### DIFF
--- a/beeline/trace.py
+++ b/beeline/trace.py
@@ -74,7 +74,7 @@ class Tracer(object):
                 span.add_context({
                     "app.exception_type": str(type(e)),
                     "app.exception_string": stringify_exception(e),
-                    "app.exception_traceback": traceback.format_exc(),
+                    "app.exception_stacktrace": traceback.format_exc(),
                 })
             raise
         finally:

--- a/beeline/trace.py
+++ b/beeline/trace.py
@@ -9,6 +9,7 @@ import random
 import struct
 import sys
 import threading
+import traceback
 import inspect
 from collections import defaultdict
 
@@ -73,6 +74,7 @@ class Tracer(object):
                 span.add_context({
                     "app.exception_type": str(type(e)),
                     "app.exception_string": stringify_exception(e),
+                    "app.exception_traceback": traceback.format_exc(),
                 })
             raise
         finally:


### PR DESCRIPTION
**What**
Add app.exception_traceback to context when an exception is thrown 

**Why?**
`app.exception_type` and `app.exception_string` give us insight into "what" exception occurred, adding `app.exception_traceback` gives more insight into "why" the exception occurred. It also keeps us from having to manually add context for every exception in our code.