### PR TITLE
Fix deprecations related to unittest usage

### DIFF
--- a/beeline/propagation/test_honeycomb.py
+++ b/beeline/propagation/test_honeycomb.py
@@ -15,9 +15,9 @@ class TestMarshalUnmarshal(unittest.TestCase):
         header = hc.marshal_propagation_context(pc)
         new_trace_id, new_parent_id, new_trace_fields = hc.unmarshal_propagation_context(
             header)
-        self.assertEquals(trace_id, new_trace_id)
-        self.assertEquals(parent_id, new_parent_id)
-        self.assertEquals(trace_fields, new_trace_fields)
+        self.assertEqual(trace_id, new_trace_id)
+        self.assertEqual(parent_id, new_parent_id)
+        self.assertEqual(trace_fields, new_trace_fields)
 
     def test_roundtrip_with_dataset(self):
         '''Verify that we can successfully roundtrip (marshal and unmarshal)'''
@@ -29,10 +29,10 @@ class TestMarshalUnmarshal(unittest.TestCase):
         header = hc.marshal_propagation_context(pc)
         new_trace_id, new_parent_id, new_trace_fields, new_dataset = hc.unmarshal_propagation_context_with_dataset(
             header)
-        self.assertEquals(dataset, new_dataset)
-        self.assertEquals(trace_id, new_trace_id)
-        self.assertEquals(parent_id, new_parent_id)
-        self.assertEquals(trace_fields, new_trace_fields)
+        self.assertEqual(dataset, new_dataset)
+        self.assertEqual(trace_id, new_trace_id)
+        self.assertEqual(parent_id, new_parent_id)
+        self.assertEqual(trace_fields, new_trace_fields)
 
 
 class TestHoneycombHTTPTraceParserHook(unittest.TestCase):
@@ -43,8 +43,8 @@ class TestHoneycombHTTPTraceParserHook(unittest.TestCase):
             'X-HoNEyComb-TrACE': header_value,
         })
         pc = hc.http_trace_parser_hook(req)
-        self.assertEquals(pc.trace_id, "bloop")
-        self.assertEquals(pc.parent_id, "scoop")
+        self.assertEqual(pc.trace_id, "bloop")
+        self.assertEqual(pc.parent_id, "scoop")
         # FIXME: We should have a legitimate header with trace_field and dataset_id set
 
     def test_no_header(self):
@@ -63,5 +63,5 @@ class TestHoneycombHTTPTracePropagationHook(unittest.TestCase):
             trace_id, parent_id, trace_fields, dataset)
         headers = hc.http_trace_propagation_hook(pc)
         self.assertIn('X-Honeycomb-Trace', headers)
-        self.assertEquals(headers['X-Honeycomb-Trace'],
+        self.assertEqual(headers['X-Honeycomb-Trace'],
                           "1;dataset=blorp%20blorp,trace_id=bloop,parent_id=scoop,context=eyJrZXkiOiAidmFsdWUifQ==")

--- a/beeline/propagation/test_honeycomb.py
+++ b/beeline/propagation/test_honeycomb.py
@@ -64,4 +64,4 @@ class TestHoneycombHTTPTracePropagationHook(unittest.TestCase):
         headers = hc.http_trace_propagation_hook(pc)
         self.assertIn('X-Honeycomb-Trace', headers)
         self.assertEqual(headers['X-Honeycomb-Trace'],
-                          "1;dataset=blorp%20blorp,trace_id=bloop,parent_id=scoop,context=eyJrZXkiOiAidmFsdWUifQ==")
+                         "1;dataset=blorp%20blorp,trace_id=bloop,parent_id=scoop,context=eyJrZXkiOiAidmFsdWUifQ==")

--- a/beeline/propagation/test_w3c.py
+++ b/beeline/propagation/test_w3c.py
@@ -72,4 +72,4 @@ class TestW3CHTTPTracePropagationHook(unittest.TestCase):
         self.assertEqual(headers['traceparent'],
                          _TEST_TRACEPARENT_HEADER)
         self.assertEqual(headers['tracestate'],
-                          _TEST_TRACESTATE_HEADER)
+                         _TEST_TRACESTATE_HEADER)

--- a/beeline/propagation/test_w3c.py
+++ b/beeline/propagation/test_w3c.py
@@ -70,6 +70,6 @@ class TestW3CHTTPTracePropagationHook(unittest.TestCase):
         self.assertIn('traceparent', headers)
         self.assertIn('tracestate', headers)
         self.assertEqual(headers['traceparent'],
-                          _TEST_TRACEPARENT_HEADER)
+                         _TEST_TRACEPARENT_HEADER)
         self.assertEqual(headers['tracestate'],
                           _TEST_TRACESTATE_HEADER)

--- a/beeline/propagation/test_w3c.py
+++ b/beeline/propagation/test_w3c.py
@@ -28,18 +28,18 @@ class TestW3CMarshalUnmarshal(unittest.TestCase):
         tracestate_header = w3c.marshal_tracestate(pc)
 
         # Make sure marshalled headers are as we expect.
-        self.assertEquals(_TEST_TRACEPARENT_HEADER, traceparent_header)
-        self.assertEquals(_TEST_TRACESTATE_HEADER, tracestate_header)
+        self.assertEqual(_TEST_TRACEPARENT_HEADER, traceparent_header)
+        self.assertEqual(_TEST_TRACESTATE_HEADER, tracestate_header)
 
         new_trace_id, new_parent_id, new_trace_flags = w3c.unmarshal_traceparent(
             traceparent_header)
         new_tracestate = w3c.unmarshal_tracestate(tracestate_header)
 
         # Check round-trip values are the same as start values.
-        self.assertEquals(_TEST_TRACE_ID, new_trace_id)
-        self.assertEquals(_TEST_PARENT_ID, new_parent_id)
-        self.assertEquals(_TEST_TRACE_FLAGS, new_trace_flags)
-        self.assertEquals(_TEST_TRACESTATE, new_tracestate)
+        self.assertEqual(_TEST_TRACE_ID, new_trace_id)
+        self.assertEqual(_TEST_PARENT_ID, new_parent_id)
+        self.assertEqual(_TEST_TRACE_FLAGS, new_trace_flags)
+        self.assertEqual(_TEST_TRACESTATE, new_tracestate)
 
 
 class TestW3CHTTPTraceParserHook(unittest.TestCase):
@@ -47,9 +47,9 @@ class TestW3CHTTPTraceParserHook(unittest.TestCase):
         '''Test that the hook properly parses W3C trace headers'''
         req = DictRequest(_TEST_HEADERS)
         pc = w3c.http_trace_parser_hook(req)
-        self.assertEquals(pc.trace_id, _TEST_TRACE_ID)
-        self.assertEquals(pc.parent_id, _TEST_PARENT_ID)
-        self.assertEquals(pc.trace_fields, {
+        self.assertEqual(pc.trace_id, _TEST_TRACE_ID)
+        self.assertEqual(pc.parent_id, _TEST_PARENT_ID)
+        self.assertEqual(pc.trace_fields, {
             "tracestate": _TEST_TRACESTATE,
             "traceflags": _TEST_TRACE_FLAGS
         })
@@ -69,7 +69,7 @@ class TestW3CHTTPTracePropagationHook(unittest.TestCase):
         headers = w3c.http_trace_propagation_hook(pc)
         self.assertIn('traceparent', headers)
         self.assertIn('tracestate', headers)
-        self.assertEquals(headers['traceparent'],
+        self.assertEqual(headers['traceparent'],
                           _TEST_TRACEPARENT_HEADER)
-        self.assertEquals(headers['tracestate'],
+        self.assertEqual(headers['tracestate'],
                           _TEST_TRACESTATE_HEADER)

--- a/beeline/test_trace.py
+++ b/beeline/test_trace.py
@@ -507,9 +507,12 @@ class TestSynchronousTracer(unittest.TestCase):
             tracer.add_trace_field('c', 3)
             tracer.finish_span(m_span)
 
-        # ensure we only added fields b and c and did not try to overwrite a
-        self.assertDictContainsSubset(
-            {'app.a': 1, 'app.b': 2, 'app.c': 3}, m_span.event.fields())
+        # Check that the new, unique fields were successfully added
+        self.assertIn("app.b", m_span.event.fields())
+        self.assertIn("app.c", m_span.event.fields())
+
+        # Check that a was not overwritten with the new value of 0.
+        self.assertEqual(m_span.event.fields()["app.a"], 1)
 
     def test_trace_context_manager_does_not_crash_if_span_is_none(self):
         m_client = Mock()


### PR DESCRIPTION
The custom test runner is not configured to include warnings the its
output. While this is a configurable options on Python 3.2+, given this
codebase is 2.7-compatible, I have not updated the configuration.

These were detected by running the test suite via
`python -m unittest discover` under Python 3.8 rather than
`poetry run tests` which uses the custom test runner.