### PR TITLE
Fix requests patch to correctly build span name

### DIFF
--- a/beeline/patch/requests.py
+++ b/beeline/patch/requests.py
@@ -20,9 +20,14 @@ def request(_request, instance, args, kwargs):
 
     try:
         resp = None
+
+        # Required as Python treats the `or` keyword differently in string
+        # interpolation vs. when assigning a variable.
+        method = kwargs.get('method') or args[0]
+
         beeline.add_context({
-            "name": "requests_%s" % kwargs.get('method') or args[0],
-            "request.method": kwargs.get('method') or args[0],
+            "name": "requests_%s" % method,
+            "request.method": method,
             "request.url": kwargs.get('url') or args[1],
         })
         resp = _request(*args, **kwargs)


### PR DESCRIPTION
When using the Python `or` keyword in a string interpolation, it behaves differently to when you use it in assignment. This PR resolves an instance of this issue in the requests library patch. This helps avoid situations where the span name would be `requests_None`.

This code snippet demonstrates the issue:

```python

print("Hello %s" % None or "Dave")
# Outputs "Hello None"

name = None or "Dave"
print("Hello %s" % name)
# Outputs "Hello Dave"
```

I found this issue when making requests via the `request` library's `Session` object. This code is a minimum reproduction of the issue including the existing `beeline-python` release.

```python
import beeline
import requests

from beeline.patch.requests import *


def check_if_span_name_is_broken_presend_hook(event):
    if 'name' in event and event['name'] == 'requests_None':
        raise Exception("event name has stringified `None` in it!")


beeline.init(
    presend_hook=check_if_span_name_is_broken_presend_hook,
)


if __name__ == "__main__":
    trace = beeline.start_trace()
    requests.Session().get("https://google.com")
    beeline.finish_trace(trace)
```