### PR TITLE
Fix requests patch context omission for [400,600) status codes

### DIFF
--- a/beeline/patch/requests.py
+++ b/beeline/patch/requests.py
@@ -39,7 +39,7 @@ def request(_request, instance, args, kwargs):
         })
         raise
     finally:
-        if resp:
+        if resp is not None:
             content_type = resp.headers.get('content-type')
             if content_type:
                 beeline.add_context_field(


### PR DESCRIPTION
The class `requests.Response` defines `__bool__` as:

```python
class Response(object):
    ...
    def __bool__(self):
        """Returns True if :attr:`status_code` is less than 400.

        This attribute checks if the status code of the response is between
        400 and 600 to see if there was a client error or a server error. If
        the status code, is between 200 and 400, this will return True. This
        is **not** a check to see if the response code is ``200 OK``.
        """
        return self.ok
```

This resulted in spans for requests with [400,600) status codes not including `content_type`, `content_length` or `status_code` in the span context, even when they were available.