### PR TITLE
Default w3c sampled flag to 01

### DIFF
--- a/beeline/propagation/test_w3c.py
+++ b/beeline/propagation/test_w3c.py
@@ -4,6 +4,7 @@ import beeline.propagation.honeycomb as hc
 import beeline.propagation.w3c as w3c
 
 _TEST_TRACEPARENT_HEADER = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00"
+_TEST_TRACEPARENT_HEADER_DEFAULT_TRACEFLAGS = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
 _TEST_TRACESTATE_HEADER = "foo=bar,bar=baz"
 
 _TEST_HEADERS = {
@@ -73,3 +74,12 @@ class TestW3CHTTPTracePropagationHook(unittest.TestCase):
                          _TEST_TRACEPARENT_HEADER)
         self.assertEqual(headers['tracestate'],
                          _TEST_TRACESTATE_HEADER)
+
+    def test_defaults_trace_flags_to_sampled(self):
+        pc = PropagationContext(
+            _TEST_TRACE_ID, _TEST_PARENT_ID
+        )
+        headers = w3c.http_trace_propagation_hook(pc)
+        self.assertIn('traceparent', headers)
+        self.assertEqual(headers['traceparent'],
+                         _TEST_TRACEPARENT_HEADER_DEFAULT_TRACEFLAGS)

--- a/beeline/propagation/w3c.py
+++ b/beeline/propagation/w3c.py
@@ -70,7 +70,7 @@ def marshal_traceparent(propagation_context):
 
     trace_flags = propagation_context.trace_fields.get('traceflags')
     if not trace_flags:
-        trace_flags = "00"
+        trace_flags = "01"
 
     traceparent_header = "00-{}-{}-{}".format(
         propagation_context.trace_id,


### PR DESCRIPTION
Receiving OTEL instrumentation ignores spans coming with the 00 sampled flag.

This is a stop-gap measure to ensure w3c parser hooks work with an OTEL receiver. Ideally, we would like to set the sampled flag based on an actual sampler, but that requires further investigation.