### PR TITLE
Capture exception details in AWS Lambda middleware.

### DIFF
--- a/beeline/middleware/awslambda/__init__.py
+++ b/beeline/middleware/awslambda/__init__.py
@@ -1,3 +1,5 @@
+import traceback
+
 import beeline
 from beeline.propagation import Request
 # In Lambda, a cold start is when Lambda has to spin up a new instance of a
@@ -146,6 +148,13 @@ def beeline_wrapper(handler=None, record_input=True, record_output=True):
                 beeline.add_context_field('app.response', resp)
 
             return resp
+        except Exception as e:
+            beeline.add_context({
+                "app.exception_type": str(type(e)),
+                "app.exception_string": beeline.internal.stringify_exception(e),
+                "app.exception_stacktrace": traceback.format_exc(),
+            })
+            raise e
         finally:
             # This remains false for the lifetime of the module
             COLD_START = False

--- a/beeline/middleware/awslambda/test_awslambda.py
+++ b/beeline/middleware/awslambda/test_awslambda.py
@@ -229,7 +229,7 @@ class TestLambdaWrapper(unittest.TestCase):
                 'meta.cold_start': ANY,
                 'name': 'handler'}, ANY)
             m_add_context.assert_called_once_with({
-                'app.exception_type': "<class 'ValueError'>",
+                'app.exception_type': ANY,  # representation changes between 2.7 and 3.x
                 'app.exception_string': 'something went wrong',
                 'app.exception_stacktrace': ANY
             })


### PR DESCRIPTION
Trace field names match the ones used in `Tracer`:
https://github.com/honeycombio/beeline-python/blob/2ab8dea5d195096755199ac9badfe671f408bb9d/beeline/trace.py#L74-L78

closes https://github.com/honeycombio/beeline-python/issues/153

