### PR TITLE
Avoid using deprecated Django request.is_ajax()

### DIFF
--- a/beeline/middleware/django/__init__.py
+++ b/beeline/middleware/django/__init__.py
@@ -97,7 +97,7 @@ class HoneyMiddlewareBase(object):
             "request.scheme": request.scheme,
             "request.secure": request.is_secure(),
             "request.query": request.GET.dict(),
-            "request.xhr": request.is_ajax(),
+            "request.xhr": request.headers.get('x-requested-with') == 'XMLHttpRequest',
         }
 
     def get_context_from_response(self, request, response):
@@ -183,6 +183,6 @@ class HoneyMiddlewareWithPOST(HoneyMiddleware):
             "request.scheme": request.scheme,
             "request.secure": request.is_secure(),
             "request.query": request.GET.dict(),
-            "request.xhr": request.is_ajax(),
+            "request.xhr": request.headers.get('x-requested-with') == 'XMLHttpRequest',
             "request.post": request.POST.dict(),
         }


### PR DESCRIPTION
Addresses #138

Django 3.1 deprecated the `is_ajax` method on `HttpRequest` and added a `RemovedInDjango40Warning`. The [release notes state](https://docs.djangoproject.com/en/3.1/releases/3.1/#id2):

 > If you are writing your own AJAX detection method, request.is_ajax() can be reproduced exactly as request.headers.get('x-requested-with') == 'XMLHttpRequest'.