### PR TITLE
Handle stringifying more types of parameters in flask DB middleware

### DIFF
--- a/beeline/middleware/flask/__init__.py
+++ b/beeline/middleware/flask/__init__.py
@@ -94,7 +94,7 @@ class HoneyDBMiddleware(object):
                 param = "%s=" % k
                 if type(v) == datetime.datetime:
                     v = v.isoformat()
-                param += "%s" % v
+                param += str(v)
                 params.append(param)
 
         self.state.span = beeline.start_span(context={


### PR DESCRIPTION
Fixes https://github.com/honeycombio/beeline-python/issues/159

When this happens it causes a server error in the application.