### PR TITLE
Always return True for sampling when sample rate is 1

### DIFF
--- a/beeline/test_trace.py
+++ b/beeline/test_trace.py
@@ -5,6 +5,8 @@ import datetime
 import json
 import unittest
 import re
+import os
+import binascii
 
 from libhoney import Event
 
@@ -120,6 +122,10 @@ class TestTraceSampling(unittest.TestCase):
 
             self.assertLessEqual(sampled, acceptable_upper_bound)
             self.assertGreaterEqual(sampled, acceptable_lower_bound)
+
+    def should_sample_always_returns_true_when_sample_rate_is_1(self):
+        for _ in range(1000):
+            self.assertTrue(_should_sample(binascii.b2a_hex(os.urandom(16)), 1))
 
 
 class TestSynchronousTracer(unittest.TestCase):

--- a/beeline/trace.py
+++ b/beeline/trace.py
@@ -373,6 +373,10 @@ class Span(object):
 
 
 def _should_sample(trace_id, sample_rate):
+    # Always return True if sample rate is 1
+    if sample_rate == 1:
+        return True
+
     sample_upper_bound = MAX_INT32 / sample_rate
     # compute a sha1
     sha1 = hashlib.sha1()


### PR DESCRIPTION
## Which problem is this PR solving?
With a sample rate of 1, we don't need to calculate the hash and check if it's within the bounds, we should fast return true.

- Fixes #184 

## Short description of the changes
- updates `_should_sample` to always return `True` when sample rate is 1
- add test to verify behaviour

