### PR TITLE
Add example app using Flask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,10 @@ dist
 build
 env
 venv
+pyvenv.cfg
 .eggs
+lib
+bin
 
 .vscode
 .coverage

--- a/examples/flask/README.md
+++ b/examples/flask/README.md
@@ -1,8 +1,15 @@
 # example flask app
 
+This simple Flask app uses auto-instrumentation and adds a manual span with trace context including the message of "Hello World".
+
+## Getting Started
+
+First set an environment variable `HONEYCOMB_API_KEY`, available from your account page.
+This will configure the server to send instrumentation events to Honeycomb in a dataset called my-flask-app.
+
 ## Download or Build
 
-First, [create and activate a virtual environment](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment):
+[Create and activate a virtual environment](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment):
 
 ```bash
 python3 -m venv env

--- a/examples/flask/README.md
+++ b/examples/flask/README.md
@@ -2,31 +2,25 @@
 
 This simple Flask app uses auto-instrumentation and adds a manual span with trace context including the message of "Hello World".
 
-## Getting Started
+## Prerequisites
 
 First set an environment variable `HONEYCOMB_API_KEY`, available from your account page.
 This will configure the server to send instrumentation events to Honeycomb in a dataset called my-flask-app.
 
-## Download or Build
+You'll also need [Poetry](https://python-poetry.org/) installed to run the example. Poetry automatically creates a virtual environment to run the example in so you don't need to manage one yourself.
 
-[Create and activate a virtual environment](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment):
-
-```bash
-python3 -m venv env
-
-source env/bin/activate
-```
+## Runing the example
 
 Then install the dependencies:
 
 ```bash
-python3 -m pip install .
+poetry install
 ```
 
 Run the application:
 
 ```bash
-flask run
+poetry run flask run
 ```
 
 The server will start listening on port 5000:
@@ -36,8 +30,4 @@ $ curl localhost:5000
 Hello World
 ```
 
-Check out results in Honeycomb! To [deactivate the virtual environment](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#leaving-the-virtual-environment):
-
-```bash
-deactivate
-```
+Check out the results in Honeycomb!

--- a/examples/flask/README.md
+++ b/examples/flask/README.md
@@ -11,7 +11,7 @@ You'll also need [Poetry](https://python-poetry.org/) installed to run the examp
 
 ## Runing the example
 
-Then install the dependencies:
+Install the dependencies:
 
 ```bash
 poetry install

--- a/examples/flask/README.md
+++ b/examples/flask/README.md
@@ -1,0 +1,36 @@
+# example flask app
+
+## Download or Build
+
+First, [create and activate a virtual environment](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment):
+
+```bash
+python3 -m venv env
+
+source env/bin/activate
+```
+
+Then install the dependencies:
+
+```bash
+python3 -m pip install .
+```
+
+Run the application:
+
+```bash
+flask run
+```
+
+The server will start listening on port 5000:
+
+```bash
+$ curl localhost:5000
+Hello World
+```
+
+Check out results in Honeycomb! To [deactivate the virtual environment](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#leaving-the-virtual-environment):
+
+```bash
+deactivate
+```

--- a/examples/flask/README.md
+++ b/examples/flask/README.md
@@ -9,7 +9,7 @@ This will configure the server to send instrumentation events to Honeycomb in a 
 
 You'll also need [Poetry](https://python-poetry.org/) installed to run the example. Poetry automatically creates a virtual environment to run the example in so you don't need to manage one yourself.
 
-## Runing the example
+## Running the example
 
 Install the dependencies:
 
@@ -23,7 +23,7 @@ Run the application:
 poetry run flask run
 ```
 
-The server will start listening on port 5000:
+Now you can `curl` the app:
 
 ```bash
 $ curl localhost:5000

--- a/examples/flask/app.py
+++ b/examples/flask/app.py
@@ -1,0 +1,21 @@
+import beeline
+import os
+
+from beeline.middleware.flask import HoneyMiddleware
+from flask import Flask
+
+honeycomb_writekey=os.environ.get("HONEYCOMB_API_KEY")
+
+beeline.init(writekey=honeycomb_writekey, dataset="my-flask-app", service_name="my-flask-app-service")
+
+# Pass your Flask app to HoneyMiddleware
+app = Flask(__name__)
+HoneyMiddleware(app, db_events=False)
+
+@app.route("/")
+def hello_world():
+  span = beeline.start_span(context={"name": "Preparing to greet the world"})
+  message = "Hello World"
+  beeline.add_trace_field('message', message)
+  beeline.finish_span(span)
+  return message

--- a/examples/flask/pyproject.toml
+++ b/examples/flask/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.poetry]
+name = "beeline-flask-example"
+version = "0.1.0"
+description = "flask example app using beeline-python"
+authors = ["honeycombio"]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+# honeycomb-beeline = "^2.17.2"
+honeycomb-beeline = { path = "../../../beeline-python" }
+flask = "^1.1.2"
+python-dotenv = "^0.14.0"

--- a/examples/flask/pyproject.toml
+++ b/examples/flask/pyproject.toml
@@ -6,6 +6,6 @@ authors = ["honeycombio"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-# honeycomb-beeline = "^2.17.2" # uncomment if not using local beeline
+honeycomb-beeline = {path = "../..", develop = true}
 flask = "^1.1.2"
 python-dotenv = "^0.14.0"

--- a/examples/flask/pyproject.toml
+++ b/examples/flask/pyproject.toml
@@ -6,7 +6,6 @@ authors = ["honeycombio"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-# honeycomb-beeline = "^2.17.2"
-honeycomb-beeline = { path = "../../../beeline-python" }
+# honeycomb-beeline = "^2.17.2" # uncomment if not using local beeline
 flask = "^1.1.2"
 python-dotenv = "^0.14.0"


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Add example app using Flask (initial plan to migrate from examples repo but the gatekeeper example is much more involved; this is a more basic example)

## Short description of the changes

- Add a few more items to `.gitignore` for virtual environment and other local files
- Add example app with Flask; auto-instrumentation and manual span with trace context

