### PR TITLE
[flask] Close trace regardless of exception

### DIFF
--- a/beeline/middleware/flask/__init__.py
+++ b/beeline/middleware/flask/__init__.py
@@ -29,7 +29,7 @@ class HoneyMiddleware(object):
             beeline.add_field('request.error_detail',
                               beeline.internal.stringify_exception(exception))
             beeline.add_field('request.error', str(type(exception)))
-        
+
         beeline.internal.send_event()
 
 

--- a/beeline/middleware/flask/__init__.py
+++ b/beeline/middleware/flask/__init__.py
@@ -29,7 +29,8 @@ class HoneyMiddleware(object):
             beeline.add_field('request.error_detail',
                               beeline.internal.stringify_exception(exception))
             beeline.add_field('request.error', str(type(exception)))
-            beeline.internal.send_event()
+        
+        beeline.internal.send_event()
 
 
 class HoneyWSGIMiddleware(object):


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #164 
- ... or, more specifically, this at least addresses [the comment added to that issue](https://github.com/honeycombio/beeline-python/issues/164#issuecomment-966485347), which seems like it may be the same as the initial poster.

## Short description of the changes

- The flask middleware has a function `_teardown_request` that adds error fields if there is an exception, and is only used when `signals.signals_available` is True. This function sends the event only in the case of an exception... but if the exception is already being handled by error handlers, this event is never sent because it's no longer an exception. when it hits this code. This PR moves the `send_event` outside of the if block to ensure the event is always sent, regardless of whether it was an exception (or an already-handled exception).

