### PR TITLE
[flask] fix: Remove condition on status code

### DIFF
--- a/beeline/middleware/flask/__init__.py
+++ b/beeline/middleware/flask/__init__.py
@@ -47,9 +47,7 @@ class HoneyWSGIMiddleware(object):
         def _start_response(status, headers, *args):
             status_code = int(status[0:4])
             beeline.add_context_field("response.status_code", status_code)
-            if status_code != 500:
-                beeline.finish_trace(root_span)
-            elif status_code == 500 and not signals.signals_available:
+            if not signals.signals_available:
                 beeline.finish_trace(root_span)
 
             return start_response(status, headers, *args)


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Follow up on comment on #190.
- Although the potential second `send_event()` is a noop, it's better to avoid that.

## Short description of the changes

- Remove status code check for `beeline.finish_trace` and only check `not signals.signals_available`. 

There are no tests specifically testing against Flask with Signals. To confirm behavior, I added blinker (simple usage to ensure `signals_available` is True) and a basic error handler to EGS and tested name-service before and after changes with and without year-service also running.

```py
from blinker import Namespace
my_signals = Namespace()
model_saved = my_signals.signal('model-saved')
```
...
```py
@app.errorhandler(Exception)
def basic_error(e):
    return 'An error occurred: ' + str(e), 500
```

Traces should have root spans and behavior is unchanged.