### PR TITLE
Prepare v2.17.3 release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -19,5 +19,3 @@ values =
 [bumpversion:file:beeline/version.py]
 
 [bumpversion:file:pyproject.toml]
-search = "version = \"{current_version}\" # Update using bump2version"
-replace = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = False
 tag = False
-current_version = 2.17.2
+current_version = 2.17.3
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}{build}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # beeline-python changelog
 
+## 2.17.3 2021-12-01
+
+### Fixes
+
+- Remove condition on status code (#191) | [@JamieDanielson](https://github.com/JamieDanielson)
+- Close trace regardless of exception (#190) | [@vreynolds](https://github.com/vreynolds)
+
+### Maintenance
+
+- Update dependabot to monthly (#194) | [@vreynolds](https://github.com/vreynolds)
+- Add python 3.9 and 3.10 to test matrix (#192) | [@vreynolds](https://github.com/vreynolds)
+- Add example app using Flask (#189) | [@JamieDanielson](https://github.com/JamieDanielson)
+- Empower apply-labels action to apply labels (#187) | [robbkidd](https://github.com/robbkidd)
+
 ## 2.17.2 2021-10-19
 
 ### Fixes

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,15 +1,9 @@
 # Releasing
 
-- Use `bump2version`, available in the installed project dependencies, to update the version number. For example, to bump from v1.1.1 to the next patch version:
-
-```shell
-> bump2version patch                  # 1.1.1 -> 1.1.2-dev0
-> bump2version --allow-dirty release  # 1.1.2-dev0 -> 1.1.2
-```
-
-- Confirm the version number update appears in the project files defined in `.bumpversion.cfg`.
-- Update `CHANGELOG.md` with the changes since the last release.
-- Commit changes, push, and open a release preparation pull request for review.
-- Once the pull request is merged, fetch the updated `main` branch.
-- Apply a tag for the new version on the merged commit: vX.Y.Z, for example v1.1.2.
-- Push the new version tag up to the project repository to kick off build and artifact publishing to GitHub and PyPI.
+1. Add release entry to [changelog](./CHANGELOG.md)
+2. Update version using `bump2version --new-version 1.12.0 patch` (NOTE: the `patch` is reqiured for the command to execute but doesn't mean anything as you're supplying a full version)
+3. Open a PR with the above, and merge that into main
+4. Create new tag on merged commit with the new version (e.g. `v2.3.1`)
+5. Push the tag upstream (this will kick off the release pipeline in CI)
+6. Copy change log entry for newest version into draft GitHub release created as part of CI publish steps
+7. 

--- a/beeline/version.py
+++ b/beeline/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.17.2'  # Update using bump2version
+VERSION = '2.17.3'  # Update using bump2version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "honeycomb-beeline"
-version = "2.17.2" # Update using bump2version
+version = "2.17.3" # Update using bump2version
 description = "Honeycomb library for easy instrumentation"
 authors = ["Honeycomb.io <feedback@honeycomb.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Prepares the v2.17.3 release

## Short description of the changes
- Updates version to 2.17.3
- Adds changelog entry
- Fix bumpversion config so it will run
- Update release docs to use updated bump2version command