### PR TITLE
Use wrapt instead of functools.wraps in order to preserve function si…

### DIFF
--- a/beeline/test_suite.py
+++ b/beeline/test_suite.py
@@ -21,7 +21,6 @@ def get_test_suite():
             else:
                 ts.addTest(inner_test_group)
         filtered_test_suite.addTest(ts)
-
     return filtered_test_suite
 
 


### PR DESCRIPTION
…gnatures.


<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Fixes #197 

## Short description of the changes

- Changes existing decorators that use only `functools.wraps` to use the `wrapt.decorator` decorator instead. This allows beeline traced functions to keep their original signature intact. 

