### PR TITLE
add a db.call_count rollup field for number of database queries on django root spans

### DIFF
--- a/beeline/middleware/django/__init__.py
+++ b/beeline/middleware/django/__init__.py
@@ -53,6 +53,7 @@ class HoneyDBWrapper(object):
                 "db.query": sql,
                 "db.query_args": params,
             })
+            beeline.add_rollup_field("db.call_count", 1)
 
             try:
                 db_call_start = datetime.datetime.now()


### PR DESCRIPTION
This new `db.call_count` rollup field will set a value on the root span
equal to the number of times a SQL query is made in a Django request.
This metric allows folks to, out of the box, find N+1 query problems
before they show up as performance issues, and to differentiate the
simpler cases of N+1 performance problems from other, more complicated
ones.

Currently, there's no way to do "aggregate of aggregate" queries in
Honeycomb that would let folks sum up the number of times a given span
name (like the ones made in HoneyDBWrapper) shows up in trace and then
group by request.path (or similar groupings) to find the p90 (or similar
aggregate calcuation) of those sums.

That means the alternative to adding this metric would be for folks to
either 1) use latency as a proxy for performance problems and then drill
down to specific requests to find out there were many N+1 queries
happening (which requires there being a very obvious performance problem
when you'd rather catch it early) or 2) essentially replace
HoneyMiddleware, HoneyDBWrapper, and so on with their own versions.

It's tricky to provide generic hooks here because Django injects
middleware by referencing global factories by name in strings, so a more
generic hook system is left out of this change.

As I mentioned in #sdk-python, I'm happy to hear that this is outside
the bounds and the Honeycomb solution would be for us to maintain our
own versions of HoneyMiddleware, HoneyDBWrapper, and the like. Just
trying to suss out the boundaries for this project.

Finally, and unfortunately, it looks like there's no easy way to use
Django's db work to test this. That's probably outside my timebox for
this, but hopefully this is obvious enough to be okay with review.

