### PR TITLE
add rollup SQL duration time to Django traces

### DIFF
--- a/beeline/middleware/django/__init__.py
+++ b/beeline/middleware/django/__init__.py
@@ -59,8 +59,9 @@ class HoneyDBWrapper(object):
                 db_call_start = datetime.datetime.now()
                 result = execute(sql, params, many, context)
                 db_call_diff = datetime.datetime.now() - db_call_start
-                beeline.add_context_field(
-                    "db.duration", db_call_diff.total_seconds() * 1000)
+                duration = db_call_diff.total_seconds() * 1000
+                beeline.add_context_field("db.duration", duration)
+                beeline.add_rollup_field("db.total_duration", duration)
             except Exception as e:
                 beeline.add_context_field("db.error", str(type(e)))
                 beeline.add_context_field(


### PR DESCRIPTION
Out of #205 (and internal conversation at my org), adding a rollup field
that includes how much time was spent executing SQL queries was also
desirable for an out-of-the-box experience. This adds that field.

There was a name collision with the already existing `db.duration` here
and the similarly named variable in the Go beeline that is used for
total time, so we choose the `db.total_duration` name here.
