### PR TITLE
feat: Add Environment & Services support

### DIFF
--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -85,18 +85,20 @@ class Beeline(object):
         if not writekey:
             writekey = os.environ.get('HONEYCOMB_API_KEY', '')
         if not writekey:
-            self.log(
-                'writekey not set! set the writekey if you want to send data to honeycomb')
+            logging.error(
+                'writekey not set! set the writekey if you want to send data to honeycomb'
+            )
 
         if IsClassicKey(writekey):
             if not dataset:
                 dataset = os.environ.get('HONEYCOMB_DATASET', '')
             if not dataset:
-                self.log(
-                    'dataset not set! set a value for dataset if you want to send data to honeycomb')
+                logging.error(
+                    'dataset not set! set a value for dataset if you want to send data to honeycomb'
+                )
         else:
             if dataset:
-                self.log(
+                logging.error(
                     'dataset will be ignored in favor of service name'
                 )
 
@@ -114,11 +116,11 @@ class Beeline(object):
                 service_name += ":" + process_name
             else:
                 service_name += ":python"
-            self.log(
+            logging.error(
                 'service name not set! service name will be ' + service_name
             )
             if not IsClassicKey(writekey):
-                self.log(
+                logging.error(
                     'data will be sent to unknown_service'
                 )
 
@@ -127,7 +129,7 @@ class Beeline(object):
             dataset = service_name
             if dataset.strip() != dataset:
                 # whitespace detected. trim whitespace, warn on diff
-                self.log(
+                logging.error(
                     'service name has unexpected spaces'
                 )
                 dataset = service_name.strip()

--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -10,6 +10,7 @@ from beeline.trace import SynchronousTracer
 from beeline.version import VERSION
 from beeline import internal
 import beeline.propagation.default
+import beeline.propagation
 import sys
 # pyflakes
 assert internal
@@ -74,6 +75,9 @@ class Beeline(object):
         if debug:
             self._init_logger()
 
+        def IsClassicKey(writekey):
+            return len(writekey) == 32
+
         # allow setting some values from the environment
         if not writekey:
             writekey = os.environ.get('HONEYCOMB_WRITEKEY', '')
@@ -93,6 +97,11 @@ class Beeline(object):
             user_agent_addition=USER_AGENT_ADDITION,
             debug=debug,
         )
+
+        if IsClassicKey():
+            beeline.propagation.propagate_dataset = True
+        else:
+            beeline.propagation.propagate_dataset = False
 
         self.log('initialized honeycomb client: writekey=%s dataset=%s service_name=%s',
                  writekey, dataset, service_name)

--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -87,9 +87,9 @@ class Beeline(object):
 
         if IsClassicKey(writekey):
             if not dataset:
-               dataset = os.environ.get('HONEYCOMB_DATASET', '')
+                dataset = os.environ.get('HONEYCOMB_DATASET', '')
             if not dataset:
-               self.log(
+                self.log(
                     'dataset not set! set a value for dataset if you want to send data to honeycomb')
         else:
             if dataset:

--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -97,13 +97,22 @@ class Beeline(object):
                     'dataset will be ignored in favor of service name'
                 )
 
+        default_service_name = "unknown_service"
+        process_name = os.environ.get('PROCESS_EXECUTABLE_NAME', '')
         if not service_name:
             service_name = os.environ.get('HONEYCOMB_SERVICE')
-        # also check SERVICE_NAME just in case, otherwise set default
+        # also check SERVICE_NAME just in case
         if not service_name:
-            service_name = os.environ.get('SERVICE_NAME', 'unknown_service:python')
+            service_name = os.environ.get('SERVICE_NAME', '')
+        # no service name, set default
+        if not service_name:
+            service_name = default_service_name
+            if process_name:
+                service_name += ":" + process_name
+            else:
+                service_name += ":python"
             self.log(
-                'service name not set! service name will be unknown_service:python'
+                'service name not set! service name will be ' + service_name
             )
             if not IsClassicKey(writekey):
                 self.log(

--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -120,8 +120,16 @@ class Beeline(object):
                 )
 
         if not IsClassicKey(writekey):
-            # overwrite dataset with service name, trim whitespace
-            dataset = service_name.strip()
+            # set dataset based on service name
+            dataset = service_name
+            if dataset.strip() != dataset:
+                # whitespace detected. trim whitespace, warn on diff
+                self.log(
+                    'service name has unexpected spaces'
+                )
+                dataset = service_name.strip()
+
+            # set default, truncate to unknown_service if needed
             if dataset == "" or dataset.startswith("unknown_service"):
                 dataset = "unknown_service"
 

--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -81,6 +81,9 @@ class Beeline(object):
         # allow setting some values from the environment
         if not writekey:
             writekey = os.environ.get('HONEYCOMB_WRITEKEY', '')
+        # also check API_KEY just in case
+        if not writekey:
+            writekey = os.environ.get('HONEYCOMB_API_KEY', '')
         if not writekey:
             self.log(
                 'writekey not set! set the writekey if you want to send data to honeycomb')

--- a/beeline/propagation/__init__.py
+++ b/beeline/propagation/__init__.py
@@ -6,6 +6,7 @@ import beeline
 def propagate_dataset():
     return bool
 
+
 class PropagationContext(object):
     '''
     PropagationContext represents information that can either be read from, or

--- a/beeline/propagation/__init__.py
+++ b/beeline/propagation/__init__.py
@@ -3,6 +3,9 @@ from abc import ABCMeta, abstractmethod
 import beeline
 
 
+def propagate_dataset():
+    return bool
+
 class PropagationContext(object):
     '''
     PropagationContext represents information that can either be read from, or

--- a/beeline/propagation/honeycomb.py
+++ b/beeline/propagation/honeycomb.py
@@ -96,8 +96,8 @@ def unmarshal_propagation_context_with_dataset(trace_header):
         elif k == 'context':
             context = json.loads(base64.b64decode(v.encode()).decode())
         elif k == 'dataset':
-                if beeline.propagation.propagate_dataset:
-                    dataset = unquote(v)
+            if beeline.propagation.propagate_dataset:
+                dataset = unquote(v)
 
     # context should be a dict
     if context is None:

--- a/beeline/propagation/honeycomb.py
+++ b/beeline/propagation/honeycomb.py
@@ -52,7 +52,7 @@ def marshal_propagation_context(propagation_context):
                   "context={}".format(trace_fields)]
 
     if beeline.propagation.propagate_dataset and propagation_context.dataset:
-            components.insert(0, "dataset={}".format(quote(propagation_context.dataset)))
+        components.insert(0, "dataset={}".format(quote(propagation_context.dataset)))
 
     trace_header = "{};{}".format(version, ",".join(components))
 

--- a/beeline/propagation/honeycomb.py
+++ b/beeline/propagation/honeycomb.py
@@ -96,16 +96,11 @@ def unmarshal_propagation_context_with_dataset(trace_header):
         elif k == 'context':
             context = json.loads(base64.b64decode(v.encode()).decode())
         elif k == 'dataset':
-            dataset = unquote(v)
+                if beeline.propagation.propagate_dataset:
+                    dataset = unquote(v)
 
     # context should be a dict
     if context is None:
         context = {}
 
-    fullContext = trace_id, parent_id, context
-    fullContextWithDataset = trace_id, parent_id, context, dataset
-
-    if beeline.propagation.propagate_dataset:
-        return fullContextWithDataset
-    else:
-        return fullContext
+    return trace_id, parent_id, context, dataset

--- a/beeline/propagation/honeycomb.py
+++ b/beeline/propagation/honeycomb.py
@@ -95,9 +95,8 @@ def unmarshal_propagation_context_with_dataset(trace_header):
             parent_id = v
         elif k == 'context':
             context = json.loads(base64.b64decode(v.encode()).decode())
-        elif k == 'dataset':
-            if beeline.propagation.propagate_dataset:
-                dataset = unquote(v)
+        elif k == 'dataset' and beeline.propagation.propagate_dataset:
+            dataset = unquote(v)
 
     # context should be a dict
     if context is None:

--- a/beeline/propagation/honeycomb.py
+++ b/beeline/propagation/honeycomb.py
@@ -51,8 +51,9 @@ def marshal_propagation_context(propagation_context):
                   "parent_id={}".format(propagation_context.parent_id),
                   "context={}".format(trace_fields)]
 
-    if propagation_context.dataset:
-        components.insert(0, "dataset={}".format(quote(propagation_context.dataset)))
+    if beeline.propagation.propagate_dataset:
+        if propagation_context.dataset:
+            components.insert(0, "dataset={}".format(quote(propagation_context.dataset)))
 
     trace_header = "{};{}".format(version, ",".join(components))
 
@@ -101,4 +102,10 @@ def unmarshal_propagation_context_with_dataset(trace_header):
     if context is None:
         context = {}
 
-    return trace_id, parent_id, context, dataset
+    fullContext = trace_id, parent_id, context
+    fullContextWithDataset = trace_id, parent_id, context, dataset
+
+    if beeline.propagation.propagate_dataset:
+        return fullContextWithDataset
+    else:
+        return fullContext

--- a/beeline/propagation/honeycomb.py
+++ b/beeline/propagation/honeycomb.py
@@ -51,8 +51,7 @@ def marshal_propagation_context(propagation_context):
                   "parent_id={}".format(propagation_context.parent_id),
                   "context={}".format(trace_fields)]
 
-    if beeline.propagation.propagate_dataset:
-        if propagation_context.dataset:
+    if beeline.propagation.propagate_dataset and propagation_context.dataset:
             components.insert(0, "dataset={}".format(quote(propagation_context.dataset)))
 
     trace_header = "{};{}".format(version, ",".join(components))

--- a/beeline/propagation/test_honeycomb.py
+++ b/beeline/propagation/test_honeycomb.py
@@ -1,4 +1,5 @@
 import unittest
+import beeline.propagation
 from beeline.propagation import DictRequest, PropagationContext
 import beeline.propagation.honeycomb as hc
 
@@ -21,6 +22,7 @@ class TestMarshalUnmarshal(unittest.TestCase):
 
     def test_roundtrip_with_dataset(self):
         '''Verify that we can successfully roundtrip (marshal and unmarshal)'''
+        beeline.propagation.propagate_dataset = True
         dataset = "blorp blorp"
         trace_id = "bloop"
         parent_id = "scoop"
@@ -55,6 +57,7 @@ class TestHoneycombHTTPTraceParserHook(unittest.TestCase):
 
 class TestHoneycombHTTPTracePropagationHook(unittest.TestCase):
     def test_generates_correct_header(self):
+        beeline.propagation.propagate_dataset = True
         dataset = "blorp blorp"
         trace_id = "bloop"
         parent_id = "scoop"

--- a/beeline/propagation/test_honeycomb.py
+++ b/beeline/propagation/test_honeycomb.py
@@ -35,6 +35,7 @@ class TestMarshalUnmarshal(unittest.TestCase):
         self.assertEqual(trace_id, new_trace_id)
         self.assertEqual(parent_id, new_parent_id)
         self.assertEqual(trace_fields, new_trace_fields)
+
     def test_roundtrip_with_dataset_propagation_disabled(self):
         '''Verify that we can successfully roundtrip (marshal and unmarshal) without dataset propagation'''
         beeline.propagation.propagate_dataset = False
@@ -50,6 +51,7 @@ class TestMarshalUnmarshal(unittest.TestCase):
         self.assertEqual(trace_id, new_trace_id)
         self.assertEqual(parent_id, new_parent_id)
         self.assertEqual(trace_fields, new_trace_fields)
+
 
 class TestHoneycombHTTPTraceParserHook(unittest.TestCase):
     def test_has_header(self):
@@ -82,6 +84,7 @@ class TestHoneycombHTTPTracePropagationHook(unittest.TestCase):
         self.assertIn('X-Honeycomb-Trace', headers)
         self.assertEqual(headers['X-Honeycomb-Trace'],
                          "1;dataset=blorp%20blorp,trace_id=bloop,parent_id=scoop,context=eyJrZXkiOiAidmFsdWUifQ==")
+
     def test_generates_correct_header_with_dataset_propagation_disabled(self):
         beeline.propagation.propagate_dataset = False
         dataset = "blorp blorp"

--- a/beeline/test_trace.py
+++ b/beeline/test_trace.py
@@ -3,7 +3,6 @@ from mock import ANY, Mock, call, patch
 import base64
 import datetime
 import json
-import logging
 import unittest
 import re
 import os

--- a/beeline/test_trace.py
+++ b/beeline/test_trace.py
@@ -7,6 +7,7 @@ import unittest
 import re
 import os
 import binascii
+import beeline.propagation
 
 from libhoney import Event
 
@@ -624,6 +625,7 @@ class TestSpan(unittest.TestCase):
 
 class TestPropagationHooks(unittest.TestCase):
     def test_propagate_and_start_trace_uses_honeycomb_header(self):
+        beeline.propagation.propagate_dataset = True
         # FIXME: Test basics, including error handling and custom hooks
 
         # implicitly tests finish_span

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -1,0 +1,9 @@
+# hello world example
+
+## Setup and Run
+
+1. Set environment variable for `HONEYCOMB_API_KEY`
+1. In top-level directory of repo, run `poetry build` to create a wheel package in the `dist` directory
+1. In hello-world directory, ensure version of beeline in `pyproject.toml` matches the wheel package
+1. In hello-world directory, run `poetry install`
+1. In hello-world directory, run `poetry run python3 app.py`

--- a/examples/hello-world/app.py
+++ b/examples/hello-world/app.py
@@ -1,0 +1,21 @@
+import beeline
+import os
+
+beeline.init(
+    # Get this via https://ui.honeycomb.io/account after signing up for Honeycomb
+    writekey=os.environ.get('HONEYCOMB_API_KEY'),
+    api_host=os.environ.get('HONEYCOMB_API_ENDPOINT', 'http://api.honeycomb.io:443'),
+    # The name of your app is a good choice to start with
+    # dataset='my-python-beeline-app', # only needed for classic
+    service_name=os.environ.get('SERVICE_NAME', 'my-python-app'),
+    debug=True, # enable to see telemetry in console
+)
+
+@beeline.traced(name='hello_world')
+def hello_world():
+    print('hello world')
+    beeline.add_context_field('message', 'hello world')
+
+hello_world()
+
+beeline.close()

--- a/examples/hello-world/pyproject.toml
+++ b/examples/hello-world/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.poetry]
+name = "hello-world"
+version = "0.1.0"
+description = "print hello world"
+authors = ["honeycombio"]
+
+[tool.poetry.dependencies]
+python = "^3.9"
+honeycomb-beeline = {path = "../../dist/honeycomb_beeline-3.42.99-py3-none-any.whl", develop = false}
+# honeycomb-beeline = "^3.2.0"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- closes #212 

## Short description of the changes

Tracing scenario for environment-aware teams:

* Dataset no longer propagates across services for new environment key.
* Add field `service.name` in addition to already added `service_name`
* `ServiceName` "required"†. If unset, will warn and set `service_name` AND `service.name` to `unknown_service:<process>` or `unknown_service:language`.
* Service name is used to populate dataset name; if `unknown_service.*` then truncate to`unknown_service` for dataset name.
* Trim whitespace from dataset name
* `WriteKey` required. If unset, will warn.
* `Dataset` **ignored**. If unset, no warning (because no longer used). If set, will warn to clarify that it will be ignored in favor of service name.

Tracing scenario for classic (non-environment-aware) teams:

* Add field `service.name` in addition to already added `service_name`
* `ServiceName` "required"†. If unset, will warn.
* `WriteKey` required. If unset, will warn.
* `Dataset` required. If unset, will warn and default to `beeline-<language>`.

† While not technically required, service name is highly encouraged to avoid `unknown_service` and to instead properly describe the data being sent to Honeycomb (and the data being viewed in Honeycomb UI).

logging when missing environment variables:

```
ERROR:root:writekey not set! set the writekey if you want to send data to honeycomb
ERROR:root:service name not set! service name will be unknown_service:python
ERROR:root:data will be sent to unknown_service
```