### PR TITLE
Prepare v3.3.1 release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,16 +1,16 @@
 [bumpversion]
 commit = False
 tag = False
-current_version = 3.3.0
+current_version = 3.3.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-{release}{build}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = prod
 first_value = dev
-values = 
+values =
 	dev
 	prod
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # beeline-python changelog
 
+## 3.3.1 2022-04-12
+
+### Maintenance
+
+- Bump libhoney from 1.11.2 to 2.0.0 (#209)
+- Bump wrapt from 1.13.3 to 1.14.0 (#215)
+- Bump django from 2.2.26 to 2.2.27 (#210)
+
 ## 3.3.0 2022-03-21
 
 ### Enhancements

--- a/beeline/version.py
+++ b/beeline/version.py
@@ -1,1 +1,1 @@
-VERSION = '3.3.0'  # Update using bump2version
+VERSION = '3.3.1'  # Update using bump2version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "honeycomb-beeline"
-version = "3.3.0" # Update using bump2version
+version = "3.3.1" # Update using bump2version
 description = "Honeycomb library for easy instrumentation"
 authors = ["Honeycomb.io <feedback@honeycomb.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Prepares the v3.3.1 release. We normally don't release just for dependency updates, but the django bump includes a security fix.

## Short description of the changes
- Adds changelog entry
- Updates version to 3.3.1

