### PR TITLE
Add meta.span_type to root/subroot spans

### DIFF
--- a/beeline/test_trace.py
+++ b/beeline/test_trace.py
@@ -178,7 +178,7 @@ class TestSynchronousTracer(unittest.TestCase):
             pass
 
         tracer.start_span.assert_called_once_with(
-            context={'name': 'foo'}, parent_id='zyxw')
+            context={'name': 'foo'}, parent_id='zyxw', is_trace_root=True)
         tracer.finish_span.assert_called_once_with(mock_span)
 
     def test_trace_context_manager_starts_trace_if_trace_id_supplied(self):
@@ -210,6 +210,7 @@ class TestSynchronousTracer(unittest.TestCase):
                 'trace.trace_id': span.trace_id,
                 'trace.parent_id': span.parent_id,
                 'trace.span_id': span.id,
+                'meta.span_type': "root",
             }),
         ])
         self.assertEqual(tracer._trace.stack[0], span)
@@ -284,6 +285,7 @@ class TestSynchronousTracer(unittest.TestCase):
                 'trace.trace_id': span.trace_id,
                 'trace.parent_id': span.parent_id,
                 'trace.span_id': span.id,
+                'meta.span_type': 'subroot'
             }),
         ])
 
@@ -532,7 +534,7 @@ class TestSynchronousTracer(unittest.TestCase):
             pass
 
         tracer.start_span.assert_called_once_with(
-            context={'name': 'foo'}, parent_id=None)
+            context={'name': 'foo'}, parent_id=None, is_trace_root=True)
 
     def test_trace_with_custom_dataset(self):
         dataset = 'flibble'

--- a/beeline/test_trace.py
+++ b/beeline/test_trace.py
@@ -178,7 +178,7 @@ class TestSynchronousTracer(unittest.TestCase):
             pass
 
         tracer.start_span.assert_called_once_with(
-            context={'name': 'foo'}, parent_id='zyxw', is_trace_root=True)
+            context={'name': 'foo'}, parent_id='zyxw', is_root_span=True)
         tracer.finish_span.assert_called_once_with(mock_span)
 
     def test_trace_context_manager_starts_trace_if_trace_id_supplied(self):
@@ -534,7 +534,7 @@ class TestSynchronousTracer(unittest.TestCase):
             pass
 
         tracer.start_span.assert_called_once_with(
-            context={'name': 'foo'}, parent_id=None, is_trace_root=True)
+            context={'name': 'foo'}, parent_id=None, is_root_span=True)
 
     def test_trace_with_custom_dataset(self):
         dataset = 'flibble'

--- a/beeline/trace.py
+++ b/beeline/trace.py
@@ -101,9 +101,9 @@ class Tracer(object):
             self._trace = Trace(generate_trace_id(), dataset)
 
         # start the root span
-        return self.start_span(context=context, parent_id=parent_span_id)
+        return self.start_span(context=context, parent_id=parent_span_id, is_trace_root=True)
 
-    def start_span(self, context=None, parent_id=None):
+    def start_span(self, context=None, parent_id=None, is_trace_root=False):
         if not self._trace:
             log('start_span called but no trace is active')
             return None
@@ -117,11 +117,18 @@ class Tracer(object):
         if context:
             ev.add(data=context)
 
-        ev.add(data={
+        fields = {
             'trace.trace_id': self._trace.id,
             'trace.parent_id': parent_span_id,
             'trace.span_id': span_id,
-        })
+        }
+        if is_trace_root:
+            spanType = "root"
+            if parent_span_id:
+                spanType = "subroot"
+            fields['meta.span_type'] = spanType
+        ev.add(data=fields)
+
         is_root = len(self._trace.stack) == 0
         span = Span(trace_id=self._trace.id, parent_id=parent_span_id,
                     id=span_id, event=ev, is_root=is_root)

--- a/beeline/trace.py
+++ b/beeline/trace.py
@@ -101,9 +101,9 @@ class Tracer(object):
             self._trace = Trace(generate_trace_id(), dataset)
 
         # start the root span
-        return self.start_span(context=context, parent_id=parent_span_id, is_trace_root=True)
+        return self.start_span(context=context, parent_id=parent_span_id, is_root_span=True)
 
-    def start_span(self, context=None, parent_id=None, is_trace_root=False):
+    def start_span(self, context=None, parent_id=None, is_root_span=False):
         if not self._trace:
             log('start_span called but no trace is active')
             return None
@@ -122,7 +122,7 @@ class Tracer(object):
             'trace.parent_id': parent_span_id,
             'trace.span_id': span_id,
         }
-        if is_trace_root:
+        if is_root_span:
             spanType = "root"
             if parent_span_id:
                 spanType = "subroot"


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Adds support for recording whether a span is a root or subroot span within the trace. Root means it is the very first span across all services and subroot means it is the first span within a given service.

When starting a new trace manually, via instrumentation or via propagation, `start_trace` is used so this will ensure that meta.span_type is correctly set.

- Closes #218

## Short description of the changes
- Add is_root_span to start_span with default of `False`, adds `meta.span_type` if set
- Update start_trace to set it to `True`
- Update tests to verify new field is set correctly