### PR TITLE
docs: using FileTransmission with classic requires 32 character key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Enhancements
 
+**NOTE** If you are using the [FileTranmission](https://github.com/honeycombio/libhoney-py/blob/main/libhoney/transmission.py#L448) method and setting a false API key - and still working in Classic mode - you must update the key to be 32 characters in length to keep the same behavior.
+
 - feat: Add Environment & Services support (#213) | [@JamieDanielson](https://github.com/JamieDanielson)
 
 ## 3.2.0 2022-02-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Enhancements
 
-**NOTE** If you are using the [FileTranmission](https://github.com/honeycombio/libhoney-py/blob/main/libhoney/transmission.py#L448) method and setting a false API key - and still working in Classic mode - you must update the key to be 32 characters in length to keep the same behavior.
+**NOTE** If you are using the [FileTransmission](https://github.com/honeycombio/libhoney-py/blob/main/libhoney/transmission.py#L448) method and setting a false API key - and still working in Classic mode - you must update the key to be 32 characters in length to keep the same behavior.
 
 - feat: Add Environment & Services support (#213) | [@JamieDanielson](https://github.com/JamieDanielson)
 

--- a/README.md
+++ b/README.md
@@ -14,17 +14,15 @@ Currently, supports Django (>2), Flask, Bottle, and Tornado.
 
 Compatible with Python 3.
 
-## Get in touch
+## Updating to 3.3.0
 
-Please reach out to [support@honeycomb.io](mailto:support@honeycomb.io) or ping
-us with the chat bubble on [our website](https://www.honeycomb.io) for any
-assistance. We also welcome [bug reports](https://github.com/honeycombio/beeline-python/issues).
+Version 3.3.0 added support for Environment & Services, which changes sending behavior based on API Key.
+
+If you are using the [FileTranmission](https://github.com/honeycombio/libhoney-py/blob/main/libhoney/transmission.py#L448) method and setting a false API key - and still working in Classic mode - you must update the key to be 32 characters in length to keep the same behavior.
 
 ## Contributions
 
-Features, bug fixes and other changes to `beeline-python` are gladly accepted. Please
-open issues or a pull request with your change. Remember to add your name to the
-CONTRIBUTORS file!
+Features, bug fixes and other changes to `beeline-python` are gladly accepted.
 
 If you add a new test module, be sure and update `beeline.test_suite` to pick up the new tests.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Compatible with Python 3.
 
 Version 3.3.0 added support for Environment & Services, which changes sending behavior based on API Key.
 
-If you are using the [FileTranmission](https://github.com/honeycombio/libhoney-py/blob/main/libhoney/transmission.py#L448) method and setting a false API key - and still working in Classic mode - you must update the key to be 32 characters in length to keep the same behavior.
+If you are using the [FileTransmission](https://github.com/honeycombio/libhoney-py/blob/main/libhoney/transmission.py#L448) method and setting a false API key - and still working in Classic mode - you must update the key to be 32 characters in length to keep the same behavior.
 
 ## Contributions
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- A customer reported an issue where they accidentally adopted E&S behavior because they are using a bogus key to send data via FileTransmission.

## Short description of the changes

- Explicitly state the 32 character key check for those using a bogus key with FileTransmission
- Updated README - Issues are typically preferred over support tickets, and the Contributors file isn't really necessary anymore

