### PR TITLE
Bump libhoney from 2.1.0 to 2.1.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -152,7 +152,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "libhoney"
-version = "2.1.0"
+version = "2.1.1"
 description = "Python library for sending data to Honeycomb"
 category = "main"
 optional = false
@@ -160,7 +160,6 @@ python-versions = ">=3.5,<4"
 
 [package.dependencies]
 requests = ">=2.24.0,<3.0.0"
-six = ">=1.15.0,<2.0.0"
 statsd = ">=3.3.0,<4.0.0"
 
 [[package]]
@@ -248,7 +247,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -328,7 +327,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.5, <4"
-content-hash = "7e356457ea29fe6be6c4481335bfbe44d6e84f1bc8da11111a84f03ac40b79e7"
+content-hash = "3e108c5d0be692e165297c8c73da404dd968ac5df34ee834b6b9fa90b570059f"
 
 [metadata.files]
 astroid = [
@@ -457,8 +456,8 @@ lazy-object-proxy = [
     {file = "lazy_object_proxy-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239"},
 ]
 libhoney = [
-    {file = "libhoney-2.1.0-py3-none-any.whl", hash = "sha256:6209a225c831dc9633bb74a9f82298378053cc11b302729376d3e1c0c5e15f45"},
-    {file = "libhoney-2.1.0.tar.gz", hash = "sha256:a0fe0774fb1dddfb5bbb971d666dc727c5b8c9ed9e1fa141858c7c4468794873"},
+    {file = "libhoney-2.1.1-py3-none-any.whl", hash = "sha256:85618508d197c90e4d7f06e575b22081617cc362376f5d75230fefefc02d4016"},
+    {file = "libhoney-2.1.1.tar.gz", hash = "sha256:df330b8f59e4afe94136c3eaacac488c60430386c8b002b21d049129729cde51"},
 ]
 markupsafe = [
     {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/honeycombio/beeline-python"
 
 [tool.poetry.dependencies]
 python = ">=3.5, <4"
-libhoney = ">=1.7.0"
+libhoney = "2.1.1"
 wrapt = "^1.12.1"
 [tool.poetry.dev-dependencies]
 mock = {version = "3.0.5", python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"}


### PR DESCRIPTION
## Which problem is this PR solving?
Bumping version of libhoney to latest

## Short description of the changes
Bumping version of libhoney to 2.1.1 so a new release can be made that includes this libhoney change https://github.com/honeycombio/libhoney-py/pull/121.

