### PR TITLE
drop unnecessary backwards compatibility (remove six)

### DIFF
--- a/beeline/patch/test_urllib.py
+++ b/beeline/patch/test_urllib.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-import six
 import unittest
 from mock import Mock, patch
 
@@ -7,7 +6,6 @@ import urllib
 
 
 class TestUrllibPatch(unittest.TestCase):
-    @unittest.skipIf(six.PY2, "urllib not compatible with python2")
     def test_request_fn_injects_headers_and_returns(self):
         from beeline.patch.urllib import _urllibopen  # pylint: disable=bad-option-value,import-outside-toplevel
 

--- a/beeline/propagation/__init__.py
+++ b/beeline/propagation/__init__.py
@@ -1,4 +1,3 @@
-import six
 from abc import ABCMeta, abstractmethod
 import beeline
 
@@ -23,8 +22,7 @@ class PropagationContext(object):
         self.dataset = dataset
 
 
-@six.add_metaclass(ABCMeta)
-class Request(object):
+class Request(object, metaclass=ABCMeta):
     '''
     beeline.propagation.Request is an abstract class that defines the interface that should
     be used by middleware to pass request information into http_trace_parser_hooks. It should

--- a/beeline/propagation/honeycomb.py
+++ b/beeline/propagation/honeycomb.py
@@ -2,7 +2,7 @@ import beeline
 from beeline.propagation import PropagationContext
 import base64
 import json
-from six.moves.urllib.parse import quote, unquote
+from urllib.parse import quote, unquote
 
 
 def http_trace_parser_hook(request):

--- a/pylint.rc
+++ b/pylint.rc
@@ -537,7 +537,7 @@ init-import=no
 
 # List of qualified module names which can have objects that can redefine
 # builtins.
-redefining-builtins-modules=six.moves,past.builtins,future.builtins,io,builtins
+redefining-builtins-modules=past.builtins,future.builtins,io,builtins
 
 
 [FORMAT]


### PR DESCRIPTION
Beeline hasn't supported use under Python 2 for a while now, so we can remove compat code.

## Which problem is this PR solving?

- Resolves #227 

## Short description of the changes

- Removes uses of [six](https://pypi.org/project/six/)

![cleaning up](https://user-images.githubusercontent.com/517302/179304508-ab865f3d-d5e7-4987-ae7f-74375271a244.gif)


Note: six is still a transitive dep via dev dependencies, so it still appears in the poetry.lock.

    » poetry show --tree
    mock 3.0.5 Rolling backport of unittest.mock for all Pythons
    └── six *
    pylint 2.6.2 python code static checker
    └── astroid >=2.4.0,<2.5
        └── six >=1.12,<2.0




