### PR TITLE
fix: Django < 2.2 does not have request.headers

### DIFF
--- a/beeline/middleware/django/__init__.py
+++ b/beeline/middleware/django/__init__.py
@@ -99,7 +99,7 @@ class HoneyMiddlewareBase(object):
             "request.scheme": request.scheme,
             "request.secure": request.is_secure(),
             "request.query": request.GET.dict(),
-            "request.xhr": request.headers.get('x-requested-with') == 'XMLHttpRequest',
+            "request.xhr": request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest',
         }
 
     def get_context_from_response(self, request, response):
@@ -214,6 +214,6 @@ class HoneyMiddlewareWithPOST(HoneyMiddleware):
             "request.scheme": request.scheme,
             "request.secure": request.is_secure(),
             "request.query": request.GET.dict(),
-            "request.xhr": request.headers.get('x-requested-with') == 'XMLHttpRequest',
+            "request.xhr": request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest',
             "request.post": request.POST.dict(),
         }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- #169 
- closes #225 
- this was initially changed to stop using deprecated request.is_ajax()

## Short description of the changes

- request.headers was a nicer wrapper for headers introduced in Django 2.2
- `self.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest'` is the exact implementation of is_ajax

