### PR TITLE
[release] Prepare 3.5.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,14 +3,14 @@ commit = False
 tag = False
 current_version = 3.5.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-{release}{build}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = prod
 first_value = dev
-values = 
+values =
 	dev
 	prod
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,16 +1,16 @@
 [bumpversion]
 commit = False
 tag = False
-current_version = 3.4.2
+current_version = 3.5.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}-{release}{build}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = prod
 first_value = dev
-values =
+values = 
 	dev
 	prod
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # beeline-python changelog
+## 3.5.0 2022-09-09
+
+⚠️  Minimum supported Python version is now 3.7 ⚠️ 
+### Maintenance
+
+- Drop Python 3.5, 3.6 Support (#233) | [@emilyashley](https://github.com/emilyashley)
+- Bump minimum libhoney version to 2.3 (for python >=3.7)(#234) | [@emilyashley](https://github.com/emilyashley)
 
 ## 3.4.2 2022-09-06
 

--- a/beeline/version.py
+++ b/beeline/version.py
@@ -1,1 +1,1 @@
-VERSION = '3.4.2'  # Update using bump2version
+VERSION = '3.5.0'  # Update using bump2version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "honeycomb-beeline"
-version = "3.4.2" # Update using bump2version
+version = "3.5.0" # Update using bump2version
 description = "Honeycomb library for easy instrumentation"
 authors = ["Honeycomb.io <feedback@honeycomb.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

### Release:
#### Drop Support for Python 3.5 and 3.6 in Beeline https://github.com/honeycombio/beeline-python/pull/233

- Bump Python requirement to version 3.7 or higher, resolve dependencies.
- Follow updated pylint expectations, including using f strings instead of .format()

#### Bump libhoney version to 2.3 (for python >3.7) #234