### PR TITLE
add type hints to the traced decorator

### DIFF
--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -4,6 +4,8 @@ import logging
 import os
 import socket
 from contextlib import contextmanager
+from typing import Callable
+from typing_extensions import ParamSpec, TypeVar
 
 from libhoney import Client
 from beeline.trace import SynchronousTracer
@@ -51,6 +53,9 @@ except (ImportError, AttributeError):
 
     def in_async_code():
         return False
+
+BeelineTracedParamSpec = ParamSpec('BeelineTracedParamSpec')
+BeelineTracedReturn = TypeVar('BeelineTracedReturn')
 
 
 class Beeline(object):
@@ -271,7 +276,10 @@ class Beeline(object):
             self.tracer_impl.finish_span(span)
             span = self.tracer_impl.get_active_span()
 
-    def traced(self, name, trace_id=None, parent_id=None):
+    def traced(self, name, trace_id=None, parent_id=None) -> Callable[
+        [Callable[BeelineTracedParamSpec, BeelineTracedReturn]],
+        Callable[BeelineTracedParamSpec, BeelineTracedReturn],
+    ]:
         return traced_impl(tracer_fn=self.tracer, name=name, trace_id=trace_id, parent_id=parent_id)
 
     def traced_thread(self, fn):
@@ -779,7 +787,10 @@ def close():
     _GBL = None
 
 
-def traced(name, trace_id=None, parent_id=None):
+def traced(name, trace_id=None, parent_id=None) -> Callable[
+        [Callable[BeelineTracedParamSpec, BeelineTracedReturn]],
+        Callable[BeelineTracedParamSpec, BeelineTracedReturn],
+]:
     '''
     Function decorator to wrap an entire function in a trace span. If no trace
     is active in the current thread, starts a new trace, and the wrapping span

--- a/poetry.lock
+++ b/poetry.lock
@@ -364,9 +364,9 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "typing-extensions"
-version = "4.3.0"
+version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -420,7 +420,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7, <4"
-content-hash = "874ac376afbdf55d7483ddd4082c896262857c19b5b80043e016e1042806dad4"
+content-hash = "92a7e2a91050b4fda1de369d28fee510161b70de199eb8a6f39865bd0d9aa73b"
 
 [metadata.files]
 asgiref = [
@@ -704,8 +704,8 @@ typed-ast = [
     {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
-    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
+    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
+    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ repository = "https://github.com/honeycombio/beeline-python"
 python = ">=3.7, <4"
 libhoney = "^2.3.0"
 wrapt = "^1.12.1"
+typing_extensions = ">=3.10"
+
 [tool.poetry.dev-dependencies]
 mock = "^4.0.3"
 coverage = "^6.5.0"


### PR DESCRIPTION
## Which problem is this PR solving?

We've been adding more type checking our codebase. The beeline.traced
decorator is, unfortunately, hindering that by erasing types on the
functions its applied to. This adds the types it needs.

## Short description of the changes

Along the way, we need to add `typing_extensions` to provide types
available only in Python 3.10 and later.

I'm not sure what formatter y'all are using for this codebase (Black
made a bunch of unrelated changes happen), but lmk what I should
use
