### PR TITLE
maint: fix ci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  python: circleci/python@1.2.1
+  python: circleci/python@2.1.1
 
 jobs:
   lint:


### PR DESCRIPTION
## Which problem is this PR solving?

- newer cimg/python docker images fail to run poetry install with Exit Code 1
- looks to be related to having ANSI characters in poetry output

## Short description of the changes

- updating to latest python orb version that includes --no-ansi argument when doing poetry install

