### PR TITLE
fix: Parse version number for beeline-python/{VERSION} addition

### DIFF
--- a/beeline/__init__.py
+++ b/beeline/__init__.py
@@ -15,7 +15,7 @@ import sys
 # pyflakes
 assert internal
 
-USER_AGENT_ADDITION = "beeline-python/{VERSION}"
+USER_AGENT_ADDITION = f"beeline-python/{VERSION}"
 
 # This is the global beeline created by init
 _GBL = None


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Addresses internal bug that shows "beeline-python/{VERSION}" in the user agent rather than the parsed version number.

## Short description of the changes

-

