### PR TITLE
docs: add otel recommendation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![OSS Lifecycle](https://img.shields.io/osslifecycle/honeycombio/beeline-python?color=success)](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md)
 [![Build Status](https://circleci.com/gh/honeycombio/beeline-python.svg?style=svg)](https://app.circleci.com/pipelines/github/honeycombio/beeline-python)
 
+**Note**: Honeycomb embraces OpenTelemetry as the effective way to instrument applications. For any new observability efforts, we recommend [instrumenting with OpenTelemetry](https://docs.honeycomb.io/getting-data-in/opentelemetry/python-distro/).
+
 This package makes it easy to instrument your Python web application to send useful events to [Honeycomb](https://honeycomb.io), a service for debugging your software in production.
 
 - [Usage and Examples](https://docs.honeycomb.io/getting-data-in/beelines/beeline-python/)


### PR DESCRIPTION
## Which problem is this PR solving?
This addition to the README makes it clear that Honeycomb recommends instrumenting any new observability efforts with OpenTelemetry

## Short description of the changes
- Add paragraph to README recommending OTel