### PR TITLE
fix: fix error when cursor.lastrowid doesnt exist

### DIFF
--- a/beeline/middleware/django/__init__.py
+++ b/beeline/middleware/django/__init__.py
@@ -72,7 +72,7 @@ class HoneyDBWrapper(object):
             finally:
                 if vendor in ('postgresql', 'mysql'):
                     beeline.add_context({
-                        "db.last_insert_id": context['cursor'].cursor.lastrowid,
+                        "db.last_insert_id": getattr(context['cursor'].cursor, 'lastrowid', None),
                         "db.rows_affected": context['cursor'].cursor.rowcount,
                     })
 


### PR DESCRIPTION
## Which problem is this PR solving?

- closes #278 

## Short description of the changes

- only add `db.last_insert_id` if `lastrowid` exists on the Cursor object.

A similar fix is already in place for [Flask middleware](https://github.com/honeycombio/beeline-python/blob/main/beeline/middleware/flask/__init__.py#L113). When using psycopg2, the `lastrowid` existed but came through as 0. When using psycopg3, the `lastrowid` doesn't exist, which caused an exception.

The below screenshot shows a before and after for this fix. 

![before-and-after-lastrowid-fix](https://github.com/honeycombio/beeline-python/assets/29520003/aa5f24ce-9627-482d-b9dc-6bed3775ddc0)
