### PR TITLE
rel: prep release v3.5.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,16 +1,16 @@
 [bumpversion]
 commit = False
 tag = False
-current_version = 3.5.1
+current_version = 3.5.2
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}-{release}{build}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = prod
 first_value = dev
-values =
+values = 
 	dev
 	prod
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # beeline-python changelog
 
+## 3.5.2 2023-05-25
+
+### Fixes
+
+- fix: fix error when cursor.lastrowid doesnt exist (#281) | [@JamieDanielson](https://github.com/JamieDanielson)
+
+### Maintenance
+
+- maint(deps): bump wrapt from 1.14.1 to 1.15.0 (#264)
+- maint: Bump requests from 2.28.1 to 2.31.0 in /examples/flask (#279)
+- maint(deps): bump requests from 2.28.1 to 2.31.0 (#280)
+- maint(deps-dev): bump mock from 5.0.1 to 5.0.2 (#275)
+- maint(deps-dev): bump coverage from 7.2.3 to 7.2.5 (#273)
+- maint(deps-dev): bump django from 3.2.18 to 3.2.19 (#277)
+- maint(deps-dev): bump flask from 2.2.3 to 2.2.5 (#276)
+- maint(deps): bump sqlparse from 0.4.2 to 0.4.4 (#272)
+- maint(deps-dev): bump coverage from 7.0.5 to 7.2.3 (#269)
+- maint(deps-dev): bump flask from 2.2.2 to 2.2.3 (#266)
+- maint(deps-dev): bump mock from 5.0.0 to 5.0.1 (#260)
+- maint(deps-dev): bump django from 3.2.17 to 3.2.18 (#262)
+- maint(deps): bump werkzeug from 2.2.2 to 2.2.3 (#263)
+- maint(deps-dev): bump django from 3.2.16 to 3.2.17 (#261)
+
 ## 3.5.1 2023-01-19
 
 ### Fixes

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,22 @@
 # Releasing
 
-1. Update version using `bump2version --new-version 1.12.0 patch` (NOTE: the `patch` is reqiured for the command to execute but doesn't mean anything as you're supplying a full version)
-2. Add release entry to [changelog](./CHANGELOG.md)
-3. Open a PR with the above, and merge that into main
-4. Create new tag on merged commit with the new version (e.g. `git tag -a v2.3.1 -m "v2.3.1"`)
-5. Push the tag upstream (this will kick off the release pipeline in CI) e.g. `git push origin v2.3.1`
-6. Copy change log entry for newest version into draft GitHub release created as part of CI publish steps
-   - generate release notes via github release draft for full changelog notes and any new contributors
+Use `poetry run bump2version --new-version <version> <semver` to update the version, including both the version number and semver type.
+  (The `patch` is required for the command to execute but doesn't mean anything as you're supplying a full version).
+
+  For example, to bump from v3.5.1 to the next patch version:
+
+```sh
+> poetry run bump2version --new-version 3.5.2 patch
+```
+
+- Confirm the version number update appears in `.bumpversion.cfg`, `pyproject.toml`, and `version.py`
+- Update `CHANGELOG.md` with the changes since the last release. Consider automating with a command such as these two:
+  - `git log $(git describe --tags --abbrev=0)..HEAD --no-merges --oneline > new-in-this-release.log`
+  - `git log --pretty='%C(green)%d%Creset- %s | [%an](https://github.com/)'`
+- Commit changes, push, and open a release preparation pull request for review.
+- Once the pull request is merged, fetch the updated `main` branch.
+- Apply a tag for the new version on the merged commit (e.g. `git tag -a v3.5.2 -m "v3.5.2"`)
+- Push the tag upstream (this will kick off the release pipeline in CI) e.g. `git push origin v3.5.2`
+- Ensure that there is a draft GitHub release created as part of CI publish steps (this will also publish to PyPi).
+- Click "generate release notes" in GitHub for full changelog notes and any new contributors
+- Publish the GitHub draft release

--- a/beeline/version.py
+++ b/beeline/version.py
@@ -1,1 +1,1 @@
-VERSION = '3.5.1'  # Update using bump2version
+VERSION = '3.5.2'  # Update using bump2version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "honeycomb-beeline"
-version = "3.5.1" # Update using bump2version
+version = "3.5.2" # Update using bump2version
 description = "Honeycomb library for easy instrumentation"
 authors = ["Honeycomb.io <feedback@honeycomb.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Which problem is this PR solving?

- prep release v3.5.2

## Short description of the changes

- bump version from 3.5.1 to 3.5.2
- update changelog
- update releasing notes for added detail/clarity as seen in some of our newer active repos

