### PR TITLE
maint: Update poetry publish to use API token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
       - checkout
       - python/install-packages:
           pkg-manager: poetry
-      - run: poetry publish --build -u honeycomb -p ${PYPI_PASSWORD}
+      - run: poetry publish --build -u '__token__' -p ${PYPI_TOKEN}
 
   publish_github:
     docker:


### PR DESCRIPTION
## Which problem is this PR solving?
Update poetry publish step to use the new API token instead of a username and password.

## Short description of the changes
- Update the publish step to use an API token

