### PR TITLE
docs: document maximum supported Flask version is 2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This package makes it easy to instrument your Python web application to send use
 
 ## Compatible with
 
-Currently, supports Django (>3.2), Flask, Bottle, and Tornado.
+Currently, supports Django (>3.2), Flask(<2.4), Bottle, and Tornado.
 
 Compatible with Python >3.7.
 


### PR DESCRIPTION
## Which problem is this PR solving?

- relates to #300 

## Short description of the changes

Currently, the maximum supported Flask version is 2.3. Update the README.md to reflect that.

